### PR TITLE
Add postgres and imagen skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Data & Analysis
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
+- [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 
 ### Business & Marketing
@@ -170,6 +171,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Creative & Media
 
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
+- [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.


### PR DESCRIPTION
## New Skills

Adding two skills from [ai-skills](https://github.com/sanjay3290/ai-skills):

### postgres (Data & Analysis)
- Execute safe read-only SQL queries against PostgreSQL databases
- Multi-connection support with intelligent auto-selection
- Defense-in-depth security

### imagen (Creative & Media)
- Generate images using Google Gemini's API
- UI mockups, icons, illustrations, and visual assets
- Cross-platform support

Both skills work with Claude Code, and the SKILL.md format is compatible with other LLM tools like Codex and Gemini CLI.