### PR TITLE
Add agent-manager-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Development & Code Tools
 
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
+- [agent-manager-skill](https://github.com/fractalmind-ai/agent-manager-skill) - tmux + Python agent lifecycle manager for local CLI agents (start/stop/monitor/assign + cron scheduling).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Changelog Generator](./changelog-generator/) - Automatically creates user-facing changelogs from git commits by analyzing history and transforming technical commits into customer-friendly release notes.
 - [D3.js Visualization](https://github.com/chrisvoncsefalvay/claude-d3js-skill) - Teaches Claude to produce D3 charts and interactive data visualizations. *By [@chrisvoncsefalvay](https://github.com/chrisvoncsefalvay)*


### PR DESCRIPTION
Adds agent-manager-skill (tmux-based local CLI agent lifecycle manager) to the Development & Code Tools section.