### PR TITLE
Add manus skill for delegating tasks to Manus AI agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus) - Delegate complex tasks to Manus AI agent for deep research, market analysis, product comparisons, stock analysis, and comprehensive report generation. *By [@sanjay3290](https://github.com/sanjay3290)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds [manus](https://github.com/sanjay3290/ai-skills/tree/main/skills/manus) skill to the Data & Analysis section.

**About Manus:**
- Deep research with parallel processing
- Market analysis, competitive landscaping
- Stock/financial analysis with charts
- Comprehensive report generation

Works with Claude Code, Gemini CLI, and other LLM clients.