### PR TITLE
Add AgentFund MCP to Skills with MCP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Skills with MCP
 
+- [AgentFund](https://github.com/RioBot-Grind/agentfund-mcp) - Crowdfunding platform for AI agents on Base chain. Query projects, generate funding transactions, release milestones, and handle payments autonomously via MCP.
 - [Notion Knowledge Capture](./notion-knowledge-capture/) - Converts chats and decisions into structured Notion pages and database entries with proper linking.
 - [Notion Meeting Intelligence](./notion-meeting-intelligence/) - Preps meetings from Notion context and creates internal pre-reads plus external agendas.
 - [Notion Research Documentation](./notion-research-documentation/) - Searches Notion, synthesizes multiple pages, and writes cited research docs back to Notion.


### PR DESCRIPTION
Adding AgentFund MCP - crowdfunding platform for AI agents on Base chain.

**What it does:**
- Query AgentFund projects
- Generate funding transactions
- Release milestones
- Handle payments autonomously

MCP server for AI agents to participate in crowdfunding workflows.

https://github.com/RioBot-Grind/agentfund-mcp