### PR TITLE
Add notebooklm skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Data & Analysis
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
+- [notebooklm](https://github.com/sanjay3290/ai-skills/tree/main/skills/notebooklm) - Query and manage Google NotebookLM notebooks with persistent auth, batch/multi queries, source sync, and structured exports. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 


### PR DESCRIPTION
Adds [notebooklm](https://github.com/sanjay3290/ai-skills/tree/main/skills/notebooklm) to the **Data & Analysis** section.

Query and manage Google NotebookLM notebooks with persistent profile auth, batch/multi queries, source sync, and structured markdown/JSON exports.

**Features:**
- Single, batch, and cross-notebook comparison queries
- Remote notebook and source management (create, add, sync, delete)
- Hash-based dedupe for file uploads
- `--dry-run` on all destructive operations
- Persistent Chrome profiles for auth