### PR TITLE
Add musecl-memory skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [musecl-memory](https://github.com/musecl/musecl-memory) - Zero-dependency file-based memory sync for AI agents. Persistent memory across sessions using bash, git, and markdown — no databases or API keys.
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adding [musecl-memory](https://github.com/musecl/musecl-memory) — a zero-dependency memory sync skill for AI agents. Uses bash + git + markdown for persistent memory across sessions. Works with Claude Code, Codex, Gemini CLI, or any LLM agent.