### PR TITLE
Add pm-skills skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Collaboration & Project Management
 
 - [git-pushing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/git-pushing) - Automate git operations and repository interactions.
+- [pm-skills](https://github.com/product-on-purpose/pm-skills) - A library of 24 product management agent skills covering discovery, definition, delivery, and optimization following the agentskills.io specification. *By [@product-on-purpose](https://github.com/product-on-purpose)*
 - [review-implementing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/review-implementing) - Evaluate code implementation plans and align with specs.
 - [test-fixing](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/engineering-workflow-plugin/skills/test-fixing) - Detect failing tests and propose patches or fixes.
 


### PR DESCRIPTION
Adds [pm-skills](https://github.com/product-on-purpose/pm-skills) to the Collaboration & Project Management section.

**What it is:** A library of 24 product management agent skills covering discovery, definition, delivery, and optimization — following the [agentskills.io specification](https://agentskills.io/specification). Apache 2.0 licensed, compatible with Claude Code, Codex, Gemini CLI, Cursor, and other agent platforms.

**What problem it solves:** Product managers using AI agents lack structured, reusable skills for PM workflows. pm-skills provides ready-to-use skills for PRDs, user stories, experiment design, competitive analysis, retrospectives, and more.

**Who uses it:** Product managers and PM-adjacent engineers who use AI coding assistants.

Placed alphabetically between `git-pushing` and `review-implementing`. Happy to adjust.