### PR TITLE
Add OpenClaw platform + MoltMemory and UnderSheet skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,13 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ## Platforms
 
+### OpenClaw
+
+OpenClaw is an AI agent runtime with a SKILL.md-based skill system. Skills are installed via ClawHub (`clawhub install <slug>`).
+
+- [MoltMemory](https://github.com/ubgb/moltmemory) - Persistent thread memory + CAPTCHA solver for Moltbook. Thread continuity across sessions, feed cursor, heartbeat integration. Zero deps, pure Python. *By [@ubgb](https://github.com/ubgb)*
+- [UnderSheet](https://github.com/ubgb/undersheet) - Platform-agnostic persistent thread memory for AI agents. Works with Moltbook, Hacker News, Reddit, Discord, Twitter/X via swappable adapters. Zero deps, pure Python. *By [@ubgb](https://github.com/ubgb)*
+
 ### Claude Code (Anthropic)
 
 **Set‑up and enable skills**


### PR DESCRIPTION
Adds OpenClaw as a supported platform (uses SKILL.md format identical to Claude Code). MoltMemory and UnderSheet are open-source, zero-dependency Python skills for persistent agent memory.