### PR TITLE
Add OpenPaw skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 - [File Organizer](./file-organizer/) - Intelligently organizes files and folders by understanding context, finding duplicates, and suggesting better organizational structures.
 - [Invoice Organizer](./invoice-organizer/) - Automatically organizes invoices and receipts for tax preparation by reading files, extracting information, and renaming consistently.
+- [OpenPaw](https://github.com/daxaur/openpaw) - Installs 38 personal assistant skills for Claude Code covering email, calendar, Spotify, smart home, Slack, GitHub, Obsidian, and more. *By [@daxaur](https://github.com/daxaur)*
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.


### PR DESCRIPTION
Adding OpenPaw to the Productivity & Organization section.

OpenPaw is a CLI tool (`npx pawmode`) that installs 38 personal assistant skills for Claude Code — email, calendar, Spotify, smart home, Slack, GitHub, Obsidian, and more. Each skill is a markdown file with instructions and tool dependencies, so it fits naturally alongside the other skills in this list.

No daemon, no cloud, MIT licensed.

https://github.com/daxaur/openpaw