### PR TITLE
Add TutuoAI to community resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [TutuoAI](https://www.tutuoai.com) - AI agent skills marketplace (free + paid skill packs)
 - [Notion Skills](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0) - Notion integration skills
 
 ## License


### PR DESCRIPTION
Adds TutuoAI (https://www.tutuoai.com) to the Community Resources list as an AI agent skills marketplace.