### PR TITLE
Add TutuoAI to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [TutuoAI](https://www.tutuoai.com/?utm_source=github-awesome-llm-skills&utm_medium=community-resource&utm_campaign=first-sale) - AI tool/agent marketplace with a browsable catalog (free + paid listings).
 - [Notion Skills](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0) - Notion integration skills
 
 ## License


### PR DESCRIPTION
Adds TutuoAI (https://www.tutuoai.com) as a community resource for discovering AI tools/agents and related catalog items.