### PR TITLE
Add Human Pages MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
+- [Human Pages](https://github.com/human-pages-ai/humanpages) - MCP server that gives AI agents access to real-world people who listed themselves to be hired by agents. 31 tools including search by skill/location/equipment, job offers, and streaming payments. *By [@human-pages-ai](https://github.com/human-pages-ai)*
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 
 ### Communication & Writing


### PR DESCRIPTION
Adds [Human Pages](https://github.com/human-pages-ai/humanpages) — MCP server that gives AI agents access to real-world people who listed themselves to be hired by agents. 31 tools including search by skill/location/equipment, job offers, and streaming payments.

- Website: https://humanpages.ai
- GitHub: https://github.com/human-pages-ai/humanpages