### PR TITLE
Add newsmcp to Skills with MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Notion Meeting Intelligence](./notion-meeting-intelligence/) - Preps meetings from Notion context and creates internal pre-reads plus external agendas.
 - [Notion Research Documentation](./notion-research-documentation/) - Searches Notion, synthesizes multiple pages, and writes cited research docs back to Notion.
 - [Notion Spec To Implementation](./notion-spec-to-implementation/) - Turns Notion specs into task plans with acceptance criteria and progress tracking.
-
+- [newsmcp](https://github.com/CuriouslyCory/newsmcp) - MCP server and skill for real-time world news briefings covering 50+ regions. Provides AI agents with current events context via topic and region filtering.
 ### Document Processing
 
 - [docx](https://github.com/anthropics/skills/tree/main/document-skills/docx) - Create, edit, analyze Word docs with tracked changes, comments, formatting.


### PR DESCRIPTION
## Summary
- Adds [newsmcp](https://github.com/CuriouslyCory/newsmcp) to the Skills with MCP section
- MCP server and skill for real-time world news briefings
- Covers 50+ regions across 6 continents with topic-based filtering