### PR TITLE
Add Xquik Skill and fix Codex setup guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper) - X/Twitter data skill — MCP server, REST API, 20 extraction tools, account monitoring. Works with Claude Code, Cursor, Codex, and 40+ agents.
 
 ### Business & Marketing
 

--- a/README.md
+++ b/README.md
@@ -100,7 +100,8 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
    * **Claude (web or Desktop):** Upload a ZIP via **Settings → Capabilities → Skills** → **Upload skill**. 
    * **Claude Code (terminal):** Place the folder under `.claude/skills/` (project) or `~/.claude/skills/` (user). Claude Code discovers skills from these locations.
-   * **Other CLIs (Codex, Gemini, OpenCode, Qwen Code):** They don't use Anthropic's Skills format natively—reference your `SKILL.md` in prompts (Gemini CLI supports `@` file/context attachments).
+   * **Codex CLI:** Place the folder under `.agents/skills/` (project) or `~/.agents/skills/` (user). Codex discovers `SKILL.md` files automatically.
+   * **Other CLIs (Gemini, OpenCode, Qwen Code):** Reference your `SKILL.md` in prompts (Gemini CLI supports `@` file/context attachments).
   
 5. **Use it**
    Just ask in natural language, optionally mentioning the skill by name—for example:
@@ -118,6 +119,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Notion Research Documentation](./notion-research-documentation/) - Searches Notion, synthesizes multiple pages, and writes cited research docs back to Notion.
 - [Notion Spec To Implementation](./notion-spec-to-implementation/) - Turns Notion specs into task plans with acceptance criteria and progress tracking.
 - [Taisly Agent Kit](https://github.com/taisly/agent) - Publishes approved short-form videos through Taisly with a reusable Agent Skill, Codex plugin, CLI, and remote MCP server.
+- [Xquik](https://github.com/Xquik-dev/x-twitter-scraper/tree/master/skills/x-twitter-scraper) - Uses Xquik for X data, exports, monitoring, webhooks, and publishing through REST or MCP. *By [@Xquik-dev](https://github.com/Xquik-dev)* Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 ### Document Processing
 
@@ -235,9 +237,12 @@ By [Infrasity-Labs](https://github.com/Infrasity-Labs)
 
 **Set‑up and enable skills**
 
-* OpenAI's Codex powers GitHub Copilot and can be accessed via CLI tools for code generation and automation.
-* While Codex doesn't natively support Anthropic's Skills format, you can adapt skills by including instructions in your prompts or configuration files.
-* Best for code completion, refactoring, and generating boilerplate code across multiple programming languages.
+* Put project Skills in `.agents/skills/<skill-name>/`.
+* Put user Skills in `~/.agents/skills/<skill-name>/`.
+* Include a `SKILL.md` file in each Skill folder.
+* Start Codex inside the repository. It scans from the current directory to the root.
+* Run `/skills` or type `$` to invoke a Skill explicitly.
+* Codex can also select Skills from their frontmatter descriptions.
 
 ### Gemini CLI (Google)
 
@@ -290,6 +295,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Creating Custom Skills](https://support.claude.com/en/articles/12512198-creating-custom-skills) - Skill development guide
 - [Skills API Documentation](https://docs.claude.com/en/api/skills-guide) - API integration guide
 - [Agent Skills Blog Post](https://anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) - Engineering deep dive
+- [Building Skills for Codex](https://learn.chatgpt.com/docs/build-skills) - Author and load Skills in Codex.
 
 ### Community Resources
 


### PR DESCRIPTION
Disclosure: I maintain Xquik and the linked Skill package.

## Summary

- Add the maintained Xquik Skill under Skills with MCP.
- Cover REST, MCP, exports, monitoring, webhooks, and approved publishing.
- Fix incorrect Codex Skill discovery guidance.

## Real-World Use Case

Teams use Xquik for bounded X data workflows and production integrations.
The Skill routes each task to REST, MCP, or an export workflow.
It requires approval before private reads, writes, or persistent jobs.

## Independent Fix

The README said Codex powers GitHub Copilot and lacks native Skill support.
Current Codex loads `SKILL.md` from `.agents/skills` locations.
This patch documents project paths, user paths, and explicit invocation.

## Validation

- Read the README and contribution guidelines.
- Searched the default branch, PRs, and issues for duplicates.
- Audited all comments, reviews, threads, commits, and checks on 3 overlapping PRs.
- Installed the linked Skill for Codex, Claude Code, and Gemini CLI.
- Verified the maintained Skill source and current green source CI.
- Reviewed current credential, consent, and untrusted-content controls.
- Confirmed all added links return HTTP 200.
- Ran `git diff --check` and exact README assertions.

## Sources

- Xquik Skill: https://github.com/Xquik-dev/x-twitter-scraper/tree/master/skills/x-twitter-scraper
- Codex Skill guidance: https://learn.chatgpt.com/docs/build-skills

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
