### PR TITLE
Add steel-browser skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [pypict-claude-skill](https://github.com/omkamal/pypict-claude-skill) - Design comprehensive test cases using PICT (Pairwise Independent Combinatorial Testing) for requirements or code, generating optimized test suites with pairwise coverage.
 - [Skill Creator](./skill-creator/) - Provides guidance for creating effective Claude Skills that extend capabilities with specialized knowledge, workflows, and tool integrations.
 - [Skill Seekers](https://github.com/yusufkaraaslan/Skill_Seekers) - Automatically converts any documentation website into a Claude AI skill in minutes. *By [@yusufkaraaslan](https://github.com/yusufkaraaslan)*
+- [steel-browser](https://github.com/steel-dev/cli/tree/main/skills/steel-browser) - Session-backed browser automation for navigation, extraction, screenshots, PDFs, and multi-step web workflows. Credit: based on Steel's browser automation workflow.
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.


### PR DESCRIPTION
This adds a `steel-browser` reference in the Development & Code Tools section.

What problem it solves:
- Gives LLM workflows a reliable browser path for navigation, extraction, screenshots, PDFs, and multi-step web tasks that basic fetches or one-off scripts handle poorly.

Who uses this workflow:
- Claude Code, Codex, Gemini CLI, and similar agent users working through login flows, dynamic sites, web QA, dashboard exports, and evidence capture.

Attribution / inspiration:
- Credit: based on Steels browser automation workflow in `steel-dev/cli`.

Example use case:
- Use `steel-browser` to open a JS-heavy dashboard, extract the content, and save both screenshot and PDF artifacts.