### PR TITLE
Add StitchFlow skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [pypict-claude-skill](https://github.com/omkamal/pypict-claude-skill) - Design comprehensive test cases using PICT (Pairwise Independent Combinatorial Testing) for requirements or code, generating optimized test suites with pairwise coverage.
 - [Skill Creator](./skill-creator/) - Provides guidance for creating effective Claude Skills that extend capabilities with specialized knowledge, workflows, and tool integrations.
 - [Skill Seekers](https://github.com/yusufkaraaslan/Skill_Seekers) - Automatically converts any documentation website into a Claude AI skill in minutes. *By [@yusufkaraaslan](https://github.com/yusufkaraaslan)*
+- [StitchFlow](https://github.com/yshishenya/stitchflow) - Turns product briefs into Stitch UI screens, variants, Tailwind-ready HTML, and screenshots across Codex, Claude Code, OpenClaw, GitHub Copilot, and Gemini CLI. *By [@yshishenya](https://github.com/yshishenya)*
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.


### PR DESCRIPTION
## Summary
Add StitchFlow to the Development & Code Tools section.

## Why
StitchFlow is a portable SKILL.md-based workflow for turning product briefs into Stitch-generated UI screens, variants, Tailwind-ready HTML, and screenshots across Codex, Claude Code, OpenClaw, GitHub Copilot, and Gemini CLI.

## Repo
https://github.com/yshishenya/stitchflow