### PR TITLE
Add claude-scaffold — npx CLI for deploying Claude Code skills and hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Skill Seekers](https://github.com/yusufkaraaslan/Skill_Seekers) - Automatically converts any documentation website into a Claude AI skill in minutes. *By [@yusufkaraaslan](https://github.com/yusufkaraaslan)*
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
+- [claude-scaffold](https://github.com/pyramidheadshark/claude-scaffold) - npx CLI that deploys a complete Claude Code skills setup (CLAUDE.md, hooks, 18 domain skills, agents) to any repository in one command. Skills auto-activate via hooks based on project context. *By [@pyramidheadshark](https://github.com/pyramidheadshark)*
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 
 ### Data & Analysis


### PR DESCRIPTION
Adding claude-scaffold to the Development & Code Tools section.

claude-scaffold is an npx CLI that deploys a complete Claude Code skills setup (CLAUDE.md, hooks, 18 domain skills, agents) to any repository in one command. 18 domain skills auto-activate via UserPromptSubmit hooks based on project context — working with FastAPI routes loads `fastapi-patterns`, LangGraph code loads `langgraph-patterns`, RAG setup loads `rag-vector-db`, etc.

Cross-repo sync via `npx claude-scaffold update --all` keeps every registered repo on the same skills version.

- GitHub: https://github.com/pyramidheadshark/claude-scaffold
- npm: https://npmjs.com/package/claude-scaffold