### PR TITLE
Add skillfold-cli skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 4. **Load the skill**
 
-   * **Claude (web or Desktop):** Upload a ZIP via **Settings → Capabilities → Skills** → **Upload skill**. 
+   * **Claude (web or Desktop):** Upload a ZIP via **Settings \u2192 Capabilities \u2192 Skills** \u2192 **Upload skill**. 
    * **Claude Code (terminal):** Place the folder under `.claude/skills/` (project) or `~/.claude/skills/` (user). Claude Code discovers skills from these locations.
-   * **Other CLIs (Codex, Gemini, OpenCode, Qwen Code):** They don't use Anthropic's Skills format natively—reference your `SKILL.md` in prompts (Gemini CLI supports `@` file/context attachments).
+   * **Other CLIs (Codex, Gemini, OpenCode, Qwen Code):** They don't use Anthropic's Skills format natively\u2014reference your `SKILL.md` in prompts (Gemini CLI supports `@` file/context attachments).
   
 5. **Use it**
-   Just ask in natural language, optionally mentioning the skill by name—for example:
-   "Use the **Webapp Testing** skill to validate the checkout flow and generate `report.md`." Claude can auto-invoke relevant skills based on your request. 
+   Just ask in natural language, optionally mentioning the skill by name\u2014for example:
+   \"Use the **Webapp Testing** skill to validate the checkout flow and generate `report.md`.\" Claude can auto-invoke relevant skills based on your request. 
 
 6. **(Optional) Kickstart a repo session in Claude Code**
    Slash-commands are supported; many users run `/init` to generate a `CLAUDE.md` and bootstrap context before working.
@@ -141,6 +141,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [pypict-claude-skill](https://github.com/omkamal/pypict-claude-skill) - Design comprehensive test cases using PICT (Pairwise Independent Combinatorial Testing) for requirements or code, generating optimized test suites with pairwise coverage.
 - [Skill Creator](./skill-creator/) - Provides guidance for creating effective Claude Skills that extend capabilities with specialized knowledge, workflows, and tool integrations.
 - [Skill Seekers](https://github.com/yusufkaraaslan/Skill_Seekers) - Automatically converts any documentation website into a Claude AI skill in minutes. *By [@yusufkaraaslan](https://github.com/yusufkaraaslan)*
+- [skillfold-cli](./skillfold-cli/) - Compile, validate, visualize, and run multi-agent pipelines across Claude Code, Codex, Gemini CLI, Cursor, Copilot, and Windsurf. *By [@byronxlg](https://github.com/byronxlg)*
 - [test-driven-development](https://github.com/obra/superpowers/tree/main/skills/test-driven-development) - Use when implementing any feature or bugfix, before writing implementation code.
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
@@ -203,7 +204,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Claude Code (Anthropic)
 
-**Set‑up and enable skills**
+**Set\u2011up and enable skills**
 
 * **Installation:** Ensure Node 20+ and Visual Studio Code are installed. Claude Code enhances Claude's coding capabilities with runtime access, terminal support, and code generation.
 * **Getting Started:** Launch Claude Code from VS Code or terminal. Claude Code automatically discovers skills from `.claude/skills/` (project) or `~/.claude/skills/` (user) directories.
@@ -211,15 +212,15 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Claude Desktop (Anthropic)
 
-**Set‑up and enable skills**
+**Set\u2011up and enable skills**
 
 * Claude Desktop provides a native application experience for Claude across Windows, macOS, and Linux platforms.
-* Access skills through Settings → Capabilities → Skills. Upload custom skills as ZIP files or select from available community skills.
+* Access skills through Settings \u2192 Capabilities \u2192 Skills. Upload custom skills as ZIP files or select from available community skills.
 * Desktop app supports all Claude features including file uploads, code generation, and real-time collaboration.
 
 ### Codex CLI (OpenAI)
 
-**Set‑up and enable skills**
+**Set\u2011up and enable skills**
 
 * OpenAI's Codex powers GitHub Copilot and can be accessed via CLI tools for code generation and automation.
 * While Codex doesn't natively support Anthropic's Skills format, you can adapt skills by including instructions in your prompts or configuration files.
@@ -227,23 +228,23 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Gemini CLI (Google)
 
-**Set‑up and enable skills**
+**Set\u2011up and enable skills**
 
-* Install Node 20+ and then install Gemini CLI via `npm install -g @google/gemini-cli` or run it on‑demand with `npx @google/gemini-cli`.
-* Run `gemini` and sign in with your Google account; a browser window will open for authentication. Gemini CLI currently doesn't have built‑in support for Anthropic skills, but you can follow skill instructions by loading your own `SKILL.md` file and referencing it in prompts. Use the `@` symbol to upload files containing your skill instructions.
+* Install Node 20+ and then install Gemini CLI via `npm install -g @google/gemini-cli` or run it on\u2011demand with `npx @google/gemini-cli`.
+* Run `gemini` and sign in with your Google account; a browser window will open for authentication. Gemini CLI currently doesn't have built\u2011in support for Anthropic skills, but you can follow skill instructions by loading your own `SKILL.md` file and referencing it in prompts. Use the `@` symbol to upload files containing your skill instructions.
 
 ### OpenCode (Open-source CLI)
 
-**Set‑up and enable skills**
+**Set\u2011up and enable skills**
 
-* Install OpenCode with a one‑line script: `curl -fsSL https://opencode.ai/install | bash`.
+* Install OpenCode with a one\u2011line script: `curl -fsSL https://opencode.ai/install | bash`.
 * Run `opencode auth login` and choose your provider (e.g., Cerebras) to configure your API key.
 * Start the interface with `opencode` and initialize your project context using `/init`.
 * OpenCode doesn't natively load Anthropic skills, but you can place a `skills/` folder in your project and ask OpenCode to read the `SKILL.md` file; this approximates skills functionality and lets you reuse instructions across tools.
 
 ### Qwen Code (Alibaba)
 
-**Set‑up and enable skills**
+**Set\u2011up and enable skills**
 
 * Ensure Node 20+ is installed, then install Qwen Code with `npm install -g @qwen-code/qwen-code@latest` and verify with `qwen --version`. Alternatively, clone the repository and install locally.
 * Start a session by running `qwen`. Qwen Code currently doesn't support Anthropic skills directly, but you can still adopt the skill pattern by creating a `skills/` directory and prompting Qwen Code to follow the instructions in your `SKILL.md` files.

--- a/skillfold-cli/SKILL.md
+++ b/skillfold-cli/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: skillfold-cli
+description: Use the skillfold compiler to manage multi-agent pipeline configs
+version: 1.19.0
+---
+
+# Skillfold CLI
+
+Use the skillfold compiler to manage multi-agent pipeline configs. Compile, validate, inspect, and visualize pipelines defined in skillfold.yaml.
+
+## Commands
+
+- `npx skillfold` - Compile the pipeline config
+- `npx skillfold init [dir]` - Scaffold a new pipeline project
+- `npx skillfold validate` - Validate config without compiling
+- `npx skillfold list` - Display pipeline summary
+- `npx skillfold graph --html` - Interactive pipeline visualization
+- `npx skillfold run --target claude-code` - Execute the pipeline
+- `npx skillfold search [query]` - Find skills on npm
+
+## Targets
+
+Compile to any platform:
+
+- `--target claude-code` - .claude/agents/*.md
+- `--target cursor` - .cursor/rules/*.mdc
+- `--target codex` - AGENTS.md
+- `--target copilot` - .github/instructions/*.md
+- `--target gemini` - .gemini/agents/*.md
+- `--target windsurf` - .windsurf/rules/*.md
+
+## Install
+
+```bash
+npm install -g skillfold
+```
+
+Source: https://github.com/byronxlg/skillfold


### PR DESCRIPTION
## What problem it solves

[Skillfold](https://github.com/byronxlg/skillfold) is a multi-agent pipeline compiler that compiles YAML config into standard SKILL.md files for Claude Code, Codex, Gemini CLI, Cursor, Copilot, and Windsurf. It already ships 11 agent skills in standard format as part of its shared library.

The **skillfold-cli** skill teaches agents how to use the compiler itself - compiling, validating, inspecting, and visualizing multi-agent pipelines defined in `skillfold.yaml`.

## Who uses this workflow

Teams building multi-agent AI pipelines who need a single config to target multiple platforms. The CLI skill lets agents manage their own pipeline configs - scaffolding new projects, validating configs, running pipelines, and searching for reusable skills on npm.

## Attribution

**Source:** [byronxlg/skillfold](https://github.com/byronxlg/skillfold) - the skill is adapted from `library/skills/skillfold-cli/SKILL.md` in the skillfold repo.

## Example usage

```
Use the skillfold-cli skill to compile my pipeline config for Claude Code and Cursor targets.
```