### PR TITLE
Add hand-drawn-diagrams: Excalidraw diagram skill with animation and hosted edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Creative & Media
 
+- [hand-drawn-diagrams](https://github.com/muthuishere/hand-drawn-diagrams) - Generate hand-drawn Excalidraw diagrams from a prompt — animated SVG, hosted edit link, and PNG export. Works with Claude Code, Codex, and any agent supporting standard skill paths. *By [@muthuishere](https://github.com/muthuishere)*
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.


### PR DESCRIPTION
## Add hand-drawn-diagrams

**Repo:** https://github.com/muthuishere/hand-drawn-diagrams  
**Author:** Muthukumaran Navaneethakrishnan ([@muthuishere](https://github.com/muthuishere))

### What it does

An agent skill that generates hand-drawn Excalidraw diagrams from a natural language prompt. It picks the right diagram type (architecture, UX flows, teaching diagrams, funnels, wireframes…), lays out the elements, and delivers:

- A hosted edit link — opens in Excalidraw editor in the browser, no app install needed
- An animated SVG that draws itself stroke by stroke
- PNG export on request

Works with Claude Code, Codex, and any agent supporting standard skill paths.

### Why it fits here

Added to **Creative & Media** alongside Canvas Design and Slack GIF Creator — useful for anyone who wants hand-drawn visual diagrams without opening Excalidraw from scratch.