### PR TITLE
Add Product & Brand Naming skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
+- [Product & Brand Naming](https://github.com/glacierphonk/naming) - Metaphor-driven naming for products, SaaS, brands, and open source projects that produces memorable, meaningful names. *By [@glacierphonk](https://github.com/glacierphonk)*
 
 ### Creative & Media
 


### PR DESCRIPTION
## Summary

Adds a link to the Product & Brand Naming skill under Communication & Writing.

## What problem it solves

Naming products, SaaS apps, brands, bots, and open source projects is one of the hardest non-technical decisions in product development. This skill uses a metaphor-driven process to generate memorable, meaningful names — avoiding generic AI-generated suggestions.

## Who uses this workflow

Solo developers, indie hackers, and small teams who need to name new products, services, or brands without hiring a branding agency.

## Example usage

"Name my fridge inventory tracking Telegram bot" → produces a shortlist of metaphor-grounded names with rationale, domain availability considerations, and brand personality fit.