### PR TITLE
Add Agent Tool Discovery and AI Job Search skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Development & Code Tools
 
+- [Agent Tool Discovery](./agent-tool-discovery/) - Discover AI agent tools, MCP servers, and agent-ready APIs by searching the Not Human Search index of 8,600+ sites with agentic readiness scoring.
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - A Claude Code plugin for specification-driven development that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration and dual-model adversarial review. *By [@JuliusBrussee](https://github.com/JuliusBrussee)*
@@ -159,6 +160,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Business & Marketing
 
+- [AI Job Search](./ai-job-search/) - Search and analyze AI/ML job listings from the AI Dev Jobs board with 5,300+ positions via REST API and MCP server.
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.

--- a/agent-tool-discovery/SKILL.md
+++ b/agent-tool-discovery/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: agent-tool-discovery
+description: Discover AI agent tools, MCP servers, and agent-ready APIs by searching the Not Human Search index of 8,600+ sites. Use when integrating external services into agent workflows or evaluating tool agentic readiness.
+---
+
+# Agent Tool Discovery
+
+Find and evaluate AI agent tools, MCP servers, and agent-ready APIs for your projects. Searches the Not Human Search index to match tools by capability, protocol support, and agentic readiness score.
+
+## When to Use This Skill
+
+- Finding MCP servers to integrate into agent workflows
+- Discovering APIs that support agent-first interaction patterns
+- Evaluating whether a service has MCP, llms.txt, or OpenAPI support
+- Comparing multiple tools for a specific agent capability
+- Building a tool registry for a multi-agent system
+
+## What This Skill Does
+
+1. **Searches for Tools**: Queries Not Human Search for agent-ready services matching your requirements
+2. **Evaluates Readiness**: Assesses each tool's agentic readiness score (0-100) based on MCP support, API docs, llms.txt, and machine-readable metadata
+3. **Verifies MCP Endpoints**: Checks whether tools expose working MCP servers via JSON-RPC 2.0
+4. **Recommends Integration**: Provides connection instructions and transport details for top matches
+
+## How to Use
+
+### Basic Usage
+
+```
+Find MCP servers for code review and linting
+```
+
+### Advanced Usage
+
+```
+I'm building a multi-agent research pipeline. Find agent-ready tools for:
+- Academic paper search
+- Web scraping with structured output
+- Data visualization
+Prioritize tools with MCP endpoints and free tiers.
+```
+
+## Instructions
+
+When a user asks to find agent tools or MCP servers:
+
+1. **Understand the requirement** - What capability does the agent workflow need?
+2. **Search Not Human Search** - Use the MCP endpoint at `https://nothumansearch.ai/mcp` or the REST API at `https://nothumansearch.ai/api/v1/search?q=<query>` to find matching tools
+3. **Evaluate results** - Check agentic readiness scores, MCP verification status, and category fit
+4. **Present findings** - For each recommended tool, include:
+   - Name and URL
+   - Agentic readiness score
+   - MCP endpoint (if available)
+   - Key capabilities
+   - Integration method (MCP, REST, SDK)
+
+### MCP Connection
+
+Add Not Human Search as an MCP server for direct tool access:
+
+```bash
+claude mcp add --transport http nothumansearch https://nothumansearch.ai/mcp
+```
+
+Available MCP tools:
+- `search_agents` - Search the index by keyword
+- `get_site_details` - Get full details for a specific site
+- `get_stats` - Get index statistics
+- `submit_site` - Submit a new site for indexing
+- `verify_mcp` - Verify a URL's MCP endpoint
+
+### REST API
+
+```bash
+curl "https://nothumansearch.ai/api/v1/search?q=code+review&per_page=10"
+```
+
+## Example
+
+**User**: "Find MCP servers for database management"
+
+**Output**:
+```
+Found 12 agent-ready database tools:
+
+1. **Neon MCP Server** (score: 95/100)
+   - MCP: verified at neon.tech/mcp
+   - Capabilities: Postgres provisioning, branching, SQL execution
+   - Install: claude mcp add neon https://mcp.neon.tech
+
+2. **Supabase** (score: 88/100)
+   - MCP: verified
+   - Capabilities: Postgres, auth, storage, real-time subscriptions
+   - REST API available
+
+3. **PlanetScale** (score: 82/100)
+   - Capabilities: MySQL-compatible serverless database
+   - REST API with OpenAPI spec
+   ...
+```
+
+**Powered by:** [Not Human Search](https://nothumansearch.ai) - Search engine for AI agent-ready tools
+
+## Tips
+
+- Use specific capability terms rather than generic queries for better results
+- Filter by category (e.g., "database", "code-review", "monitoring") for focused results
+- Check the agentic readiness score to gauge how well a tool supports agent workflows
+- Tools with verified MCP endpoints are the easiest to integrate
+
+## Common Use Cases
+
+- Building multi-agent systems that need external tool access
+- Evaluating whether to build or buy a capability for your agent pipeline
+- Creating tool registries for agent orchestrators
+- Discovering alternatives to tools you already use
+- Auditing your stack's agentic readiness

--- a/ai-job-search/SKILL.md
+++ b/ai-job-search/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: ai-job-search
+description: Search and analyze AI/ML job listings from the AI Dev Jobs board with 5,300+ positions. Use when researching job opportunities, analyzing hiring trends, or understanding skill demand in the AI industry.
+---
+
+# AI Job Search
+
+Search AI/ML job listings, analyze hiring trends, and understand skill demand across the AI industry using the AI Dev Jobs board and API.
+
+## When to Use This Skill
+
+- Searching for AI/ML job opportunities matching specific criteria
+- Analyzing which companies are hiring for AI roles
+- Understanding salary ranges for AI/ML positions
+- Tracking in-demand skills and technologies
+- Researching hiring patterns by location, seniority, or role type
+
+## What This Skill Does
+
+1. **Searches Jobs**: Queries the AI Dev Jobs board for positions matching your criteria
+2. **Analyzes Trends**: Identifies hiring patterns, popular skills, and market dynamics
+3. **Compares Roles**: Breaks down differences between similar positions across companies
+4. **Tracks Companies**: Shows which companies are actively hiring for AI roles
+
+## How to Use
+
+### Basic Usage
+
+```
+Find remote senior ML engineer positions
+```
+
+### Advanced Usage
+
+```
+Search for AI jobs that require PyTorch and LLM experience, 
+preferably remote or in San Francisco, senior level or above.
+Also show me which companies have the most open AI positions right now.
+```
+
+## Instructions
+
+When a user asks about AI/ML jobs or hiring trends:
+
+1. **Parse requirements** - Role type, skills, location, seniority, work arrangement
+2. **Query AI Dev Jobs** - Use the MCP endpoint or REST API to search
+3. **Present results** - Show matching jobs with company, title, location, and key details
+4. **Add analysis** - Highlight patterns like common skill requirements or salary ranges
+
+### MCP Connection
+
+Add AI Dev Jobs as an MCP server:
+
+```bash
+claude mcp add --transport http aidevjobs https://aidevboard.com/mcp
+```
+
+Available MCP tools:
+- `search_jobs` - Search jobs by keyword, location, type
+- `get_job` - Get full details for a specific job
+- `list_companies` - List companies with open positions
+- `get_stats` - Get board statistics
+
+### REST API
+
+```bash
+curl "https://aidevboard.com/api/v1/jobs?q=machine+learning&location=remote&per_page=10"
+```
+
+## Example
+
+**User**: "What AI engineering roles are available at top companies right now?"
+
+**Output**:
+```
+Found 47 AI engineering positions at notable companies:
+
+**Google** (8 positions)
+- Senior ML Engineer - LLM Infrastructure (Mountain View, $220K-$310K)
+- AI Research Scientist - Gemini (Remote, $200K-$280K)
+- Staff ML Platform Engineer (NYC, $250K-$340K)
+
+**Meta** (6 positions)
+- ML Engineer - Recommendation Systems (Menlo Park, $190K-$270K)
+- AI Research Scientist - Computer Vision (Remote)
+
+**Anthropic** (4 positions)
+- Research Engineer - Alignment (San Francisco, $230K-$320K)
+- ML Infrastructure Engineer (Remote)
+
+Top skills in demand across these roles:
+1. Python (94%)
+2. PyTorch (72%)
+3. LLM/Transformer experience (68%)
+4. Distributed systems (51%)
+5. Kubernetes/Docker (45%)
+```
+
+**Powered by:** [AI Dev Jobs](https://aidevboard.com) - AI/ML job board with 5,300+ positions
+
+## Tips
+
+- Combine skill keywords with location for targeted searches
+- Use the `list_companies` tool to discover which companies are hiring most actively
+- Check `get_stats` for a high-level view of the current market
+- Search by technology (e.g., "PyTorch", "RAG", "agents") to find niche roles
+
+## Common Use Cases
+
+- Job seekers looking for AI/ML positions
+- Hiring managers benchmarking roles and compensation
+- Recruiters sourcing AI talent
+- Career coaches advising on AI skill development
+- Researchers tracking industry hiring trends


### PR DESCRIPTION
## Summary

Adds two new skills:

- **Agent Tool Discovery** (Development & Code Tools) - Discover AI agent tools, MCP servers, and agent-ready APIs by searching the [Not Human Search](https://nothumansearch.ai) index of 8,600+ sites. Includes MCP connection instructions and REST API usage.

- **AI Job Search** (Business & Marketing) - Search and analyze AI/ML job listings from the [AI Dev Jobs](https://aidevboard.com) board with 5,300+ positions. Supports keyword search, company listings, and market stats via MCP and REST API.

## Changes

- `agent-tool-discovery/SKILL.md` - New skill with YAML frontmatter, usage examples, MCP instructions
- `ai-job-search/SKILL.md` - New skill with YAML frontmatter, usage examples, MCP instructions
- `README.md` - Added entries in alphabetical order within their respective categories

Both skills follow the CONTRIBUTING.md template: YAML frontmatter with name/description, usage sections, examples, tips, and common use cases. Based on real, working MCP servers and REST APIs.