### PR TITLE
Add OpenAccountants to Productivity & Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [Tax Transaction Classifier](https://github.com/openaccountants/openaccountants) - Classifies bank statement transactions into tax categories and produces accountant-ready working papers. 371 skills across 134 countries. *Inspired by OpenAccountants.*
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
Adds OpenAccountants under Productivity & Organization, after tapestry.

**What it does:** 371 tax classification skills across 134 countries. Classifies bank statement transactions into VAT/GST, income tax, and social contribution categories with conservative defaults and accountant-ready working papers.

**Who uses it:** Freelancers and small businesses preparing tax figures before meeting their accountant.

**Repository:** https://github.com/openaccountants/openaccountants