### PR TITLE
Add SkillFortify to Security & Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.
 - [resemble-detect](./resemble-detect/) - Detect deepfakes in audio, image, video, and text with confidence scores, audio source tracing, watermarking, and voice-profile identity verification via the Resemble AI platform.
 - [threat-hunting-with-sigma-rules](https://github.com/jthack/threat-hunting-with-sigma-rules-skill) - Use Sigma detection rules to hunt for threats and analyze security events.
+- [SkillFortify](https://github.com/qualixar/skillfortify) - Formal verification for AI agent skills. Scans Claude Code skills and MCP servers across 22 frameworks with 100% precision on 540-skill benchmark. Supply chain security via ASBOM. `pip install skillfortify && skillfortify scan`. Backed by [arXiv:2603.00195](https://arxiv.org/abs/2603.00195).
 
 ## Platforms
 


### PR DESCRIPTION
Adding **[SkillFortify](https://github.com/qualixar/skillfortify)** to the Security & Systems section — it is a formal verification scanner purpose-built for AI agent skills (including Claude Code skills).

### Why it fits

- **22 frameworks supported** — scans Claude Code skills, MCP servers, OpenAI Agents, LangChain, CrewAI, AutoGen, and more
- **100% precision** on the 540-skill benchmark (mathematical guarantee via sound static analysis)
- **Supply chain security** via ASBOM (Agent Software Bill of Materials)
- **One command:** `pip install skillfortify && skillfortify scan`
- **Peer-reviewed research** — [arXiv:2603.00195](https://arxiv.org/abs/2603.00195), 3 external citations
- **Part of [Qualixar](https://qualixar.com)** — AI Agent Reliability Engineering platform (7 OSS products)

Thanks for maintaining this excellent curation!