### PR TITLE
Add buyer-eval-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Business & Marketing
 
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
+- [buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - Structured, evidence-based B2B software vendor evaluation skill. Engages vendor AI agents, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards with demo prep questions. Useful for procurement, RFP evaluation, and build-vs-buy decisions. *By [@salespeak-ai](https://github.com/salespeak-ai)*
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.


### PR DESCRIPTION
Adds [buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) to the Business & Marketing section.

**What it is**: Structured, evidence-based B2B software vendor evaluation skill for Claude Code. Researches the buyer's company, asks domain-expert questions per software category, engages vendor AI agents via the Salespeak Frontdoor API for verified due diligence, scores vendors across 7 dimensions with evidence tracking, and produces comparative scorecards with demo prep questions.

**License**: MIT
**Install**:
```
git clone https://github.com/salespeak-ai/buyer-eval-skill ~/.claude/skills/buyer-eval-skill
```

Fits under Business & Marketing alongside Lead Research Assistant and Competitive Ads Extractor — it addresses the buyer side of the B2B workflow (procurement, RFP evaluation, build-vs-buy decisions) where those skills address the seller/research side.