### PR TITLE
Add Skills宝 (skilery.com) to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
+- [Skills宝 (skilery.com)](https://skilery.com) - Chinese AI Skills marketplace for one-stop search and install across Claude Code, OpenCode, and more platforms
 - [Notion Skills](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0) - Notion integration skills
 
 ## License


### PR DESCRIPTION
Adds [Skills宝](https://skilery.com) to Community Resources as a Chinese AI Skills marketplace for one-stop search and install across Claude Code, OpenCode, and more platforms.\n\nRefs #102