### PR TITLE
Add unslop (Communication & Writing) and prompt-to-asset (Creative & Media)

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [article-extractor](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/article-extractor) - Extract full article text and metadata from web pages.
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
+- [unslop](https://github.com/MohamedAbdallah-14/unslop) - Removes named AI writing tells from text output: tricolons, em-dash pileups, hedging stacks, sycophancy openers, and overused vocab like "delve" and "crucial". Lint-only mode audits without rewriting. Five intensity levels. *By [@MohamedAbdallah-14](https://github.com/MohamedAbdallah-14)*
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
@@ -179,6 +180,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 - [Canvas Design](./canvas-design/) - Creates beautiful visual art in PNG and PDF documents using design philosophy and aesthetic principles for posters, designs, and static pieces.
 - [imagen](https://github.com/sanjay3290/ai-skills/tree/main/skills/imagen) - Generate images using Google Gemini's image generation API for UI mockups, icons, illustrations, and visual assets. *By [@sanjay3290](https://github.com/sanjay3290)*
+- [prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) - MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models. Zero API key for first run via Pollinations, Stable Horde, and HuggingFace free tiers. *By [@MohamedAbdallah-14](https://github.com/MohamedAbdallah-14)*
 - [Image Enhancer](./image-enhancer/) - Improves image and screenshot quality by enhancing resolution, sharpness, and clarity for professional presentations and documentation.
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.


### PR DESCRIPTION
## Add unslop and prompt-to-asset

Two additions for the Communication & Writing and Creative & Media sections.

### 1. unslop — Communication & Writing

[unslop](https://github.com/MohamedAbdallah-14/unslop) removes named AI writing tells from any text output: tricolons, em-dash pileups, hedging stacks, sycophancy openers, and overused vocabulary like "delve" and "crucial". Lint-only mode reports every flagged pattern without rewriting, so you can review before committing changes. Five intensity levels from light (strip only the most aggressive patterns) to aggressive (enforce strict human writing norms). Works as a Claude Code skill, CLI, or piped into any workflow.

### 2. prompt-to-asset — Creative & Media

[prompt-to-asset](https://github.com/MohamedAbdallah-14/prompt-to-asset) is an MCP server and CLI that generates production-ready visual assets (app icons, favicons, OG images, logos) by routing each request across 30+ image generation models — Stable Diffusion, FLUX, DALL-E, Ideogram, and others. Selects the best-fit model per prompt. Zero API key for first run via Pollinations, Stable Horde, and HuggingFace free tiers.

**Licenses:** both MIT
