### PR TITLE
Add humanize-chinese to Communication & Writing

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [brainstorming](https://github.com/obra/superpowers/tree/main/skills/brainstorming) - Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
 - [Content Research Writer](./content-research-writer/) - Assists in writing high-quality content by conducting research, adding citations, improving hooks, and providing section-by-section feedback.
 - [family-history-research](https://github.com/emaynard/claude-family-history-research-skill) - Provides assistance with planning family history and genealogy research projects.
+- [humanize-chinese](https://github.com/voidborne-d/humanize-chinese) - Detects AI-generated Chinese text and rewrites it across 7 register-specific styles (academic, casual, Zhihu, Xiaohongshu, WeChat, literary, Weibo). 20+ detection categories with weighted 0–100 scoring; specialized academic AIGC reduction tuned for CNKI / VIP / Wanfang. Pure Python, zero dependencies. *By [@voidborne-d](https://github.com/voidborne-d)*
 - [Meeting Insights Analyzer](./meeting-insights-analyzer/) - Analyzes meeting transcripts to uncover behavioral patterns including conflict avoidance, speaking ratios, filler words, and leadership style.
 - [NotebookLM Integration](https://github.com/PleasePrompto/notebooklm-skill) - Lets Claude Code chat directly with NotebookLM for source-grounded answers based exclusively on uploaded documents. *By [@PleasePrompto](https://github.com/PleasePrompto)*
 


### PR DESCRIPTION
## What this adds

A single-line entry in **Communication & Writing** for [voidborne-d/humanize-chinese](https://github.com/voidborne-d/humanize-chinese) — a skill for detecting and humanizing AI-generated Chinese text. Inserted alphabetically between `family-history-research` and `Meeting Insights Analyzer`.

## Why it fits this list

- **Use case the section currently doesn't cover**: Chinese-language detection / rewriting. Existing entries in Communication & Writing are EN-centric. AIGC detection in Chinese has different surface signals (四字成语 density, 连接词 distribution, 句长协方差, 段落对称性) than English perplexity-based detectors, and the rewriting target also differs by register (academic CNKI/VIP/Wanfang vs Xiaohongshu vs Zhihu).
- **Substance**: 20+ weighted detection categories producing a 0–100 score with sentence-level breakdown; 7 style transforms; specialized academic AIGC reduction (120+ scholarly expression replacements, 10 academic detection dimensions).
- **Pure Python, zero dependencies** — same install profile as `article-extractor` / `brainstorming` already on the list.

## License

MIT (Non-Commercial). Disclosed up front so reviewers don't need to dig.

## Diff

`+1 / -0`. README only. No other files touched.
