### PR TITLE
Add agenttrace session audit skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Development & Code Tools
 
+- [agenttrace-session-audit](./agenttrace-session-audit/) - Audits AI coding agent session logs with agenttrace for cost, failures, latency, anomalies, health gates, and diffs across Claude Code, Codex, Gemini CLI, Aider, Cursor exports, and OpenCode.
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - A Claude Code plugin for specification-driven development that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration and dual-model adversarial review. *By [@JuliusBrussee](https://github.com/JuliusBrussee)*

--- a/agenttrace-session-audit/SKILL.md
+++ b/agenttrace-session-audit/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: agenttrace-session-audit
+description: Use when you need to inspect AI coding agent session logs with agenttrace for cost, tool failures, latency, anomalies, health, diffs, or CI gate evidence.
+---
+
+# Agenttrace Session Audit
+
+Use agenttrace to audit local AI coding agent sessions before reporting status, closing a task, or tightening CI gates. It works best when the user wants evidence from Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenCode, or similar JSONL-style logs.
+
+## When to Use This Skill
+
+- The user asks what happened in recent AI coding sessions.
+- You need a cost, token, failure, latency, anomaly, or health summary.
+- You need a Markdown, JSON, HTML, or text report for a PR, release note, or incident note.
+- You need to enforce a lightweight quality gate in CI based on session health.
+
+## What This Skill Does
+
+1. **Find sessions**: Use agenttrace's doctor command to locate supported session directories.
+2. **Summarize behavior**: Produce overview, latest-session, waste, and comparison reports.
+3. **Create evidence**: Save Markdown, JSON, HTML, or text output for review.
+4. **Gate risky runs**: Use health, critical-session, and tool-failure thresholds in CI.
+
+## How to Use
+
+### Basic Usage
+
+```bash
+agenttrace --doctor
+agenttrace --overview
+agenttrace --latest -f markdown -o agenttrace-report.md
+```
+
+If the user provides a specific log directory:
+
+```bash
+agenttrace -d /path/to/session-logs --overview -f markdown -o agenttrace-report.md
+```
+
+### Chinese Output
+
+```bash
+agenttrace --overview --lang zh
+agenttrace --latest --lang zh -f markdown -o agenttrace-report.zh.md
+```
+
+### CI Gate
+
+```bash
+agenttrace --overview --fail-under-health 75 --max-tool-fail-rate 20 --fail-on-critical
+```
+
+## Example
+
+**User**: "Audit the last Codex and Claude Code runs and tell me if anything looks risky."
+
+**Output**:
+
+```text
+Ran agenttrace --doctor to confirm detected session directories, then generated a latest-session Markdown report. The risky areas are repeated tool failures in one session, elevated latency during file reads, and a health score below the CI gate threshold. No destructive actions were taken.
+```
+
+## Tips
+
+- Run `agenttrace --version` first when the local installation is unclear.
+- Prefer `--doctor` before assuming where logs live.
+- Use `-d` when the user provides an export directory.
+- Use `-f json` when another tool needs to parse the result.
+- Do not delete or rewrite session logs unless the user explicitly asks.
+
+## Common Use Cases
+
+- Summarize AI coding agent cost and token usage after a long task.
+- Compare multiple sessions before choosing which implementation path to keep.
+- Generate PR evidence showing failures, latency, health, and diffs.
+- Add a CI guardrail for critical sessions or low average health.
+
+**Inspired by:** local-first agent observability workflows using [agenttrace](https://github.com/luoyuctl/agenttrace).


### PR DESCRIPTION
Adds `agenttrace-session-audit`, a portable skill for using agenttrace to inspect AI coding agent session logs before reporting status, closing work, or adding CI evidence.

Problem solved:
- Developers running Claude Code, Codex CLI, Gemini CLI, Aider, Cursor exports, OpenCode, or similar agents need a repeatable way to summarize cost, tokens, tool failures, latency, anomalies, health, and diffs.

Who uses this workflow:
- Engineers and agent operators reviewing local AI coding sessions.
- Teams that want Markdown/JSON/HTML evidence for PRs, releases, incidents, or CI gates.

Attribution:
- Inspired by local-first agent observability workflows using agenttrace.

Validation:
- `git diff --check`
- `agenttrace --version`
- `agenttrace --demo --overview --f markdown -o /tmp/agenttrace-session-audit-smoke.md`
