### PR TITLE
Add voxflow to Creative & Media

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Slack GIF Creator](./slack-gif-creator/) - Creates animated GIFs optimized for Slack with validators for size constraints and composable animation primitives.
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
+- [voxflow](https://github.com/VoxFlowStudio/skills) - 5 skills bundled into an AI voice CLI: TTS in 200+ voices, multi-speaker podcasts, video dubbing from SRT, transcription, and short-form Remotion videos. *By [@chicogong](https://github.com/chicogong)*
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
 
 ### Productivity & Organization


### PR DESCRIPTION
Adds [voxflow](https://github.com/VoxFlowStudio/skills) to `Skills → Creative & Media`.

VoxFlow is a 14-month solo project — an AI voice/audio CLI shipping as 5 SKILL.md files (hub, podcast, transcribe, video, paper-slide) that work cross-agent (Claude Code, Cursor, Codex CLI, Gemini CLI, Cline).

Install for any agent:
```
npx skills add VoxFlowStudio/skills
```

CLI: https://www.npmjs.com/package/voxflow
Demo: https://github.com/VoxFlowStudio/skills/raw/main/demo.gif

Free tier: 10K quota/month. Backend uses Tencent TTS/ASR + multiple LLM providers behind a quota system, server-side rendering on Fly.io.