### PR TITLE
Add APort Agent Guardrails

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Development & Code Tools
 
+- [APort Agent Guardrails](https://github.com/aporthq/aport-agent-guardrails) - Runtime guardrails for AI coding agents and tool-calling workflows with pre-action authorization hooks, blocked-pattern checks, and local or API policy enforcement.
+
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - A Claude Code plugin for specification-driven development that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration and dual-model adversarial review. *By [@JuliusBrussee](https://github.com/JuliusBrussee)*


### PR DESCRIPTION
Adds APort Agent Guardrails to the Development & Code Tools section.

APort is relevant to LLM skill/tool workflows because it provides pre-action authorization and runtime policy checks before agents execute tool calls.

Submitted for aporthq/aport-integrations#19.