### PR TITLE
add authsome under Security &amp; Systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Security & Systems
 
+- [authsome](https://github.com/agentrhq/authsome) - Local credential broker for AI agents. Log in once via OAuth2 or API key, encrypted vault stores credentials, local proxy injects them at request time so agents never see the raw values. 45 providers bundled.
 - [computer-forensics](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/computer-forensics) - Digital forensics analysis and investigation techniques.
 - [file-deletion](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/file-deletion) - Secure file deletion and data sanitization methods.
 - [metadata-extraction](https://github.com/mhattingpete/claude-skills-marketplace/tree/main/computer-forensics-skills/skills/metadata-extraction) - Extract and analyze file metadata for forensic purposes.


### PR DESCRIPTION
hey, opening this to add authsome under Security & Systems.

authsome is a local credential broker for AI agents. log in once via OAuth2 or API key, encrypted vault stores credentials, a local proxy injects them at request time so agents never see the raw values. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe. ships a SKILL.md at skills/authsome/.

happy to reword the entry or move it elsewhere if Security & Systems doesn't feel right.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT