### PR TITLE
Add Alpha Insights skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Business & Marketing
 
+- [Alpha Insights](https://github.com/Ericyoung-183/alpha-insights) - Harness-enforced business research skill that turns consulting methodology, evidence grading, and report gates into repeatable market, competitor, and product analysis workflows. *By [@Ericyoung-183](https://github.com/Ericyoung-183)*
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - Structured, evidence-based B2B software vendor evaluation skill. Engages vendor AI agents, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards with demo prep questions. Useful for procurement, RFP evaluation, and build-vs-buy decisions. *By [@salespeak-ai](https://github.com/salespeak-ai)*
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.


### PR DESCRIPTION
Adds Alpha Insights to the Business & Marketing section.\n\nUse case: repeatable business research for market, competitor, product, and due-diligence analysis. The skill packages consulting methodology, evidence grading, and report gates into a reusable workflow for Claude Code and Codex Desktop.\n\nThe change follows the existing external-link format in the README and keeps the description concise.