### PR TITLE
Add SaaS Idea Validator skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">Awesome LLM Skills</h1>
+﻿<h1 align="center">Awesome LLM Skills</h1>
 
 <p align="center">
   <a href="url">
@@ -98,12 +98,12 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 4. **Load the skill**
 
-   * **Claude (web or Desktop):** Upload a ZIP via **Settings → Capabilities → Skills** → **Upload skill**. 
+   * **Claude (web or Desktop):** Upload a ZIP via **Settings ? Capabilities ? Skills** ? **Upload skill**. 
    * **Claude Code (terminal):** Place the folder under `.claude/skills/` (project) or `~/.claude/skills/` (user). Claude Code discovers skills from these locations.
-   * **Other CLIs (Codex, Gemini, OpenCode, Qwen Code):** They don't use Anthropic's Skills format natively—reference your `SKILL.md` in prompts (Gemini CLI supports `@` file/context attachments).
+   * **Other CLIs (Codex, Gemini, OpenCode, Qwen Code):** They don't use Anthropic's Skills format natively?reference your `SKILL.md` in prompts (Gemini CLI supports `@` file/context attachments).
   
 5. **Use it**
-   Just ask in natural language, optionally mentioning the skill by name—for example:
+   Just ask in natural language, optionally mentioning the skill by name?for example:
    "Use the **Webapp Testing** skill to validate the checkout flow and generate `report.md`." Claude can auto-invoke relevant skills based on your request. 
 
 6. **(Optional) Kickstart a repo session in Claude Code**
@@ -211,7 +211,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Claude Code (Anthropic)
 
-**Set‑up and enable skills**
+**Set?up and enable skills**
 
 * **Installation:** Ensure Node 20+ and Visual Studio Code are installed. Claude Code enhances Claude's coding capabilities with runtime access, terminal support, and code generation.
 * **Getting Started:** Launch Claude Code from VS Code or terminal. Claude Code automatically discovers skills from `.claude/skills/` (project) or `~/.claude/skills/` (user) directories.
@@ -219,15 +219,15 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Claude Desktop (Anthropic)
 
-**Set‑up and enable skills**
+**Set?up and enable skills**
 
 * Claude Desktop provides a native application experience for Claude across Windows, macOS, and Linux platforms.
-* Access skills through Settings → Capabilities → Skills. Upload custom skills as ZIP files or select from available community skills.
+* Access skills through Settings ? Capabilities ? Skills. Upload custom skills as ZIP files or select from available community skills.
 * Desktop app supports all Claude features including file uploads, code generation, and real-time collaboration.
 
 ### Codex CLI (OpenAI)
 
-**Set‑up and enable skills**
+**Set?up and enable skills**
 
 * OpenAI's Codex powers GitHub Copilot and can be accessed via CLI tools for code generation and automation.
 * While Codex doesn't natively support Anthropic's Skills format, you can adapt skills by including instructions in your prompts or configuration files.
@@ -235,23 +235,23 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Gemini CLI (Google)
 
-**Set‑up and enable skills**
+**Set?up and enable skills**
 
-* Install Node 20+ and then install Gemini CLI via `npm install -g @google/gemini-cli` or run it on‑demand with `npx @google/gemini-cli`.
-* Run `gemini` and sign in with your Google account; a browser window will open for authentication. Gemini CLI currently doesn't have built‑in support for Anthropic skills, but you can follow skill instructions by loading your own `SKILL.md` file and referencing it in prompts. Use the `@` symbol to upload files containing your skill instructions.
+* Install Node 20+ and then install Gemini CLI via `npm install -g @google/gemini-cli` or run it on?demand with `npx @google/gemini-cli`.
+* Run `gemini` and sign in with your Google account; a browser window will open for authentication. Gemini CLI currently doesn't have built?in support for Anthropic skills, but you can follow skill instructions by loading your own `SKILL.md` file and referencing it in prompts. Use the `@` symbol to upload files containing your skill instructions.
 
 ### OpenCode (Open-source CLI)
 
-**Set‑up and enable skills**
+**Set?up and enable skills**
 
-* Install OpenCode with a one‑line script: `curl -fsSL https://opencode.ai/install | bash`.
+* Install OpenCode with a one?line script: `curl -fsSL https://opencode.ai/install | bash`.
 * Run `opencode auth login` and choose your provider (e.g., Cerebras) to configure your API key.
 * Start the interface with `opencode` and initialize your project context using `/init`.
 * OpenCode doesn't natively load Anthropic skills, but you can place a `skills/` folder in your project and ask OpenCode to read the `SKILL.md` file; this approximates skills functionality and lets you reuse instructions across tools.
 
 ### Qwen Code (Alibaba)
 
-**Set‑up and enable skills**
+**Set?up and enable skills**
 
 * Ensure Node 20+ is installed, then install Qwen Code with `npm install -g @qwen-code/qwen-code@latest` and verify with `qwen --version`. Alternatively, clone the repository and install locally.
 * Start a session by running `qwen`. Qwen Code currently doesn't support Anthropic skills directly, but you can still adopt the skill pattern by creating a `skills/` directory and prompting Qwen Code to follow the instructions in your `SKILL.md` files.

--- a/saas-idea-validator/SKILL.md
+++ b/saas-idea-validator/SKILL.md
@@ -1,0 +1,68 @@
+﻿---
+name: saas-idea-validator
+description: Guides solo founders through structured SaaS idea validation. Problem definition, market signals, competitor landscape, and go/no-go recommendation. Use before building anything.
+---
+
+# SaaS Idea Validator
+
+Guides solo SaaS founders through structured idea validation before writing any code. Prevents building a product nobody wants by forcing a disciplined evaluation workflow.
+
+## When to Use This Skill
+
+- You have a SaaS idea and want to validate it before building
+- You are choosing between multiple product ideas
+- A friend or client suggested "you should build X" and you want to check if it is viable
+- You are transitioning from freelance/agency work to a product business
+
+## What This Skill Does
+
+1. **Problem articulation**: Describe the problem in customer language, not solution language. Forces "who has this problem, how often, and what do they do about it today?"
+2. **Market signal detection**: Searches for real demand signals such as Reddit threads, Twitter complaints, forum discussions, and "how do I..." queries that indicate people actively looking for a solution.
+3. **Competitor mapping**: Identifies direct competitors, indirect competitors, and "good enough" alternatives. Analyzes positioning, pricing, and gaps.
+4. **Willingness-to-pay assessment**: Evaluates whether the problem is painful enough and frequent enough that people would pay. Flags "vitamin vs painkiller" distinction.
+5. **Go/no-go recommendation**: Structured report with evidence, risk assessment, confidence level, and concrete next steps.
+
+## How to Use
+
+### Basic Usage
+
+```
+Validate my SaaS idea: [describe your idea in 2-3 sentences]
+```
+
+### Advanced Usage
+
+```
+I have 3 SaaS ideas. Help me validate and rank them:
+1. [Idea A]
+2. [Idea B]
+3. [Idea C]
+Constraints: solo founder, $0 ad budget, 60 days to first revenue.
+```
+
+## Example Output
+
+User validates "a tool that auto-generates changelogs from git commits for SaaS companies." Output includes:
+
+- **Problem**: SaaS teams spend 1-2 hours per release writing changelogs. Git commits are too technical for customers.
+- **Market signals**: 15+ Reddit threads, Twitter discussions with 47+ replies seeking solutions.
+- **Competitors**: Canny.io (side feature), Beamer (weak git integration), Headway (no AI). Gap: AI-generated changelogs from git diffs.
+- **Willingness to pay**: Recurring problem every 1-2 weeks, target market pays $20-100/mo for dev tools. VERDICT: Willing to pay.
+- **Recommendation: GO (Confidence: High)**. Clear demand, competitors validate market, low technical barrier, first revenue possible in 30 days.
+
+## Common Use Cases
+
+- Validating a SaaS product idea before committing weeks of build time
+- Comparing multiple ideas to decide which to build first
+- Stress-testing an idea against real market evidence
+- Getting a structured outside perspective when too close to an idea
+
+## Tips
+
+- Be specific about the target customer. "Developers" is too broad. "Solo React developers deploying on Vercel who hate writing documentation" is specific enough.
+- Weak market signals are the most important data ? do not ignore them.
+- Competitors existing is good news: it means the market exists.
+- Run this on every idea, even ones you "know" will work. Confirmation bias is the #1 startup killer.
+
+Inspired by the [SaaS Founder Claude Code Skill Pack](https://github.com/ttcd77/saas-founder-claude-pack) ? 10 custom Claude Code commands for solo SaaS founders. This skill is a free, open-source sample.
+


### PR DESCRIPTION
﻿## What this skill does

Guides solo founders through structured SaaS idea validation. Instead of building something nobody wants, this skill walks you through:

1. **Problem definition** ? articulate the pain point in customer language
2. **Market signal check** ? search for existing demand signals (Reddit, Twitter, forums)
3. **Competitor landscape** ? identify direct/indirect competitors and their positioning
4. **Customer pain assessment** ? evaluate problem frequency, severity, and willingness to pay
5. **Go/no-go recommendation** ? structured output with evidence, risks, and next steps

## Real-world use case

Every solo founder has had the experience of spending weeks building a product only to discover nobody wants it. This skill forces a disciplined validation workflow before any code is written.

## Who uses this

- Solo SaaS founders validating their next idea
- Indie hackers choosing between multiple product ideas
- Developers transitioning from freelance to product business
- Anyone who wants to avoid the "build it and they will come" trap

## Category

Business & Marketing (alongside Lead Research Assistant, Competitive Ads Extractor, Domain Name Brainstormer)
