### PR TITLE
Add DOC2MATH to Document Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [pptx](https://github.com/anthropics/skills/tree/main/document-skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/document-skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
+- [DOC2MATH](https://github.com/thebrierfox/doc2math-skill) - Extracts mathematical problem structures from documents (text, PDFs, research papers) into structured JSON: variables, operators, constraints, objectives, and uncertainty. Uses the Zero-Inference Protocol for grounded, hallucination-resistant extraction. *By [@thebrierfox](https://github.com/thebrierfox)*
 
 ### Development & Code Tools
 


### PR DESCRIPTION
## What this adds

**[DOC2MATH](https://github.com/thebrierfox/doc2math-skill)** — a mathematical structure extraction skill for Claude Code.

### What it does
- Extracts mathematical problem structures from text, PDFs, and research papers
- Outputs structured JSON: variables, operators, constraints, objectives, and uncertainty fields
- Uses the Zero-Inference Protocol — closed-world assumption, grounded claims only, inference explicitly tagged, missing values marked as MISSING
- Validated against published optimization literature (OptNet)

### Why it fits this list
Useful for researchers, engineers, and quantitative analysts who need to parse mathematical content from documents into machine-readable form. Works on any document Claude Code can read.

### Links
- Skill repo: https://github.com/thebrierfox/doc2math-skill