### PR TITLE
docs: add Sequenzy email marketing skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [sequenzy-email-marketing](https://github.com/Sequenzy/skills/tree/main/skills/sequenzy-email-marketing) - Operate Sequenzy lifecycle email marketing and transactional email workflows: subscribers, segments, campaigns, sequences, templates, and stats. *By [@Sequenzy](https://github.com/Sequenzy)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
    ## Summary
    - Adds the Sequenzy email marketing Agent Skill to the relevant skill/resource section.
    - Keeps the description neutral and aligned with nearby entries.

    ## Links
    - Skill source: https://github.com/Sequenzy/skills/tree/main/skills/sequenzy-email-marketing
- ClawHub: https://clawhub.ai/polnikale/sequenzy-email-marketing

    ## Verification
    - Reviewed the target README section and contribution format.
    - Verified the Sequenzy skill source is public.
    - Changed files: README.md

    Diff stat:
    ```
    README.md | 1 +
 1 file changed, 1 insertion(+)
    ```
