### PR TITLE
Add Ariadne Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Development & Code Tools
 
+- [Ariadne Loop](https://github.com/zhangzeyu99-web/ariadne-loop) - Writes verifiable Loop Engineering specs, agent packets, verifier gates, stop rules, rollback criteria, and JSON reports for Codex, Claude Code, OpenClaw, and AI coding agents. *By [@zhangzeyu99-web](https://github.com/zhangzeyu99-web)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - A Claude Code plugin for specification-driven development that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration and dual-model adversarial review. *By [@JuliusBrussee](https://github.com/JuliusBrussee)*


### PR DESCRIPTION
Adds Ariadne Loop to Development & Code Tools.

Ariadne Loop is a public MIT-licensed Loop Engineering skill/workbench for writing verifiable agent execution packets: inspect/act/verify/decide loops, verifier gates, stop rules, rollback criteria, and JSON reports. It is based on a real workflow for keeping Codex, Claude Code, OpenClaw, and other AI coding agents bounded and evidence-driven.

Validation:
- `git diff --check`