### PR TITLE
Add CreatorSkills marketplace to Community Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 
 - [Anthropic Skills Repository](https://github.com/anthropics/skills) - Official example skills
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
+- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
 - [Notion Skills](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0) - Notion integration skills
 


### PR DESCRIPTION
## What

Adds [CreatorSkills](https://creatorskills.co) to the **Community Resources** section — a marketplace of 30+ downloadable AI skills for content creators.

## Why

The Community Resources section already links to external platforms (claude.ai/marketplace, notion.so), and CreatorSkills is a natural complement: it's the primary third-party marketplace for production-ready SKILL.md-format skills targeting YouTube scripting, sponsorship analysis, content repurposing, and audience growth workflows.

## Entry added

```
- [CreatorSkills](https://creatorskills.co) - Marketplace of 30+ downloadable AI skills for content creators covering YouTube scripting, sponsorship analysis, content repurposing, and audience growth
```