### PR TITLE
Add AccInt MCP skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Skills with MCP
 
+- [AccInt MCP Skills](https://github.com/maxbaluev/accreted-intelligence/tree/main/plugins/claude/skills) - Routes Claude/Codex-style agents through AccInt's MCP memory loop with solve, commitments, and frames skills for scored-memory retrieval, deliberation, and outcome tracking. *By [@maxbaluev](https://github.com/maxbaluev)*
 - [Notion Knowledge Capture](./notion-knowledge-capture/) - Converts chats and decisions into structured Notion pages and database entries with proper linking.
 - [Notion Meeting Intelligence](./notion-meeting-intelligence/) - Preps meetings from Notion context and creates internal pre-reads plus external agendas.
 - [Notion Research Documentation](./notion-research-documentation/) - Searches Notion, synthesizes multiple pages, and writes cited research docs back to Notion.


### PR DESCRIPTION
## Summary
- Add AccInt MCP Skills to the Skills with MCP section.
- Link to the public AccInt skills folder containing the `solve`, `commitments`, and `frames` skills.

## Fit
AccInt's public skills route Claude/Codex-style agents through an MCP memory loop for scored-memory retrieval, deliberation frames, and outcome tracking. This matches the repository's MCP skills category and points to real `SKILL.md` artifacts rather than a hypothetical workflow.

## Validation
- `git diff --check`
- GitHub API lists `plugins/claude/skills/{solve,commitments,frames}` in `maxbaluev/accreted-intelligence`
- `curl -L https://github.com/maxbaluev/accreted-intelligence/tree/main/plugins/claude/skills` returns HTTP 200
- `curl -L https://github.com/maxbaluev` returns HTTP 200
