### PR TITLE
Add Adanos Market Sentiment skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Data & Analysis
 
+- [Adanos Market Sentiment](https://github.com/adanos-software/adanos-market-sentiment-skill) - Read-only stock and crypto sentiment workflows using Reddit, X / FinTwit, news, and Polymarket data. *By [@adanos-software](https://github.com/adanos-software)*
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.


### PR DESCRIPTION
## Summary
- Adds Adanos Market Sentiment to Data & Analysis.

## Fit
- The skill provides read-only stock and crypto sentiment workflows for LLM agents.
- It covers Reddit, X / FinTwit, news, and Polymarket sentiment sources.
- The linked repository includes the skill, usage docs, API reference, and validation coverage.

## Verification
- Verified the repository link returns HTTP 200.
- Ran git diff --check.
- Verified discoverability with gh skill search adanos.