### PR TITLE
Add agent-qa skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Development & Code Tools
 
+- [agent-qa Authoring](https://github.com/vostride/agent-qa/tree/main/skills/agent-qa-authoring) - Author natural-language web and mobile QA tests. *By [@vostride](https://github.com/vostride)*
+- [agent-qa Debug Fix](https://github.com/vostride/agent-qa/tree/main/skills/agent-qa-debug-fix) - Debug failed agent-qa runs and propose fixes. *By [@vostride](https://github.com/vostride)*
+- [agent-qa Result Triage](https://github.com/vostride/agent-qa/tree/main/skills/agent-qa-result-triage) - Triage agent-qa results by failure category. *By [@vostride](https://github.com/vostride)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - A Claude Code plugin for specification-driven development that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration and dual-model adversarial review. *By [@JuliusBrussee](https://github.com/JuliusBrussee)*


### PR DESCRIPTION
## Summary
- add agent-qa authoring, debug/fix, and result triage skills to Development & Code Tools
- link to the published SKILL.md directories in vostride/agent-qa

## Checks
- git diff --check

Disclosure: I am affiliated with Agent QA and Vostride.