### PR TITLE
Add Taisly Agent Kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Notion Meeting Intelligence](./notion-meeting-intelligence/) - Preps meetings from Notion context and creates internal pre-reads plus external agendas.
 - [Notion Research Documentation](./notion-research-documentation/) - Searches Notion, synthesizes multiple pages, and writes cited research docs back to Notion.
 - [Notion Spec To Implementation](./notion-spec-to-implementation/) - Turns Notion specs into task plans with acceptance criteria and progress tracking.
+- [Taisly Agent Kit](https://github.com/taisly/agent) - Publishes approved short-form videos through Taisly with a reusable Agent Skill, Codex plugin, CLI, and remote MCP server.
 
 ### Document Processing
 


### PR DESCRIPTION
Adds Taisly Agent Kit to Skills with MCP. The package combines a reusable agent skill, Codex plugin, CLI, and remote MCP server for short-form video publishing.

Repository: https://github.com/taisly/agent
MCP Registry: https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.taisly%2Fagent