### PR TITLE
Add LinkedIn Skills to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [LinkedIn Skills](https://github.com/sergebulaev/linkedin-skills) - 10 MIT-licensed skills for LinkedIn workflows on Claude Code and Codex: post writer with 16 tested hook formulas, humanizer that scrubs AI tells, pre-publish audit, comment and reply drafting, hook extractor, content planner, profile optimizer, and engagement analytics. *By [@sergebulaev](https://github.com/sergebulaev)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adds [LinkedIn Skills](https://github.com/sergebulaev/linkedin-skills) to the Business & Marketing section, in alphabetical order after Lead Research Assistant.

**What it is**: A bundle of 10 agent skills that cover the full LinkedIn content workflow: a post writer built on 16 tested hook formulas, a humanizer that scrubs AI tells before publishing, a pre-publish audit against current algorithm heuristics, comment and reply drafters, a hook extractor for reverse-engineering viral posts, a 7-day content planner, a profile optimizer, engager analytics, and thread monitoring.

**What problem it solves**: Founders and marketers who draft LinkedIn content with AI agents ship posts that read as AI-generated and underperform. These skills enforce voice rules, strip AI markers, and audit drafts before they go out, turning an agent into a usable LinkedIn writing assistant.

**Who uses it**: Solo founders, developer advocates, and marketing teams running their LinkedIn presence through Claude Code or Codex. The repo has 311 stars and 44 forks. Each skill is based on the author's daily posting workflow, not a hypothetical scenario.

**Platforms**: Ships as both a Claude Code plugin and a Codex plugin, with marketplace manifests for each. Every skill is a standard `SKILL.md` folder, so it also works as plain skill files on other CLIs.

**License**: MIT

**Install**:
```
/plugin marketplace add sergebulaev/linkedin-skills
```
or clone skill folders into `~/.claude/skills/`.

**Example**: "Write a LinkedIn post about our latest release using the odd-precision money formula" invokes linkedin-post-writer, which drafts the post, runs the humanizer pass, and shows the result for approval.

**Attribution**: Built and maintained by [@sergebulaev](https://github.com/sergebulaev), based on his own LinkedIn workflow.
