### PR TITLE
Add marketingskills/seo to Developer Marketing Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 - [dev-gtm-claude-skills](https://github.com/Infrasity-Labs/dev-gtm-claude-skills) - Open-source, cross-platform agent skills for Claude Code and agentskills.io-compatible platforms. These skills are for SEO, GEO (Generative Engine Optimization), AI discoverability, and developer marketing.
 By [Infrasity-Labs](https://github.com/Infrasity-Labs)
+- [marketingskills/seo](https://github.com/marketingskills/seo) - 20+ open-source SEO SKILL.md files that turn your AI agent into an SEO operator. Diagnose traffic decay, audit technical SEO, build content briefs, fix schema, and generate client reports. Install: `curl -fsSL marketingskills.net/seo | bash`.
+By [@coreyhaines31](https://github.com/coreyhaines31)
 
 ## Platforms
 


### PR DESCRIPTION
## Add marketingskills/seo

Adds [marketingskills/seo](https://github.com/marketingskills/seo) to the **Developer Marketing Skills** section — an open-source collection of 20+ SEO SKILL.md files for Claude Code, Codex, and Gemini CLI.

### What it provides
- 20+ SEO-focused SKILL.md files (traffic decay detector, technical SEO triage, schema fix writer, content brief builder, client report writer, etc.)
- Installs via one-liner: `curl -fsSL marketingskills.net/seo | bash`
- Works across Claude Code, Codex, Gemini CLI, OpenCode
- All skills are open-source (MIT license)

### Alignment with this repo
- Direct fit: **Developer Marketing Skills** section is specifically for SEO, GEO, and developer marketing tools
- Follows the same format as the existing `dev-gtm-claude-skills` entry
- Real use case: enables AI agents to execute SEO workflows autonomously