### PR TITLE
Add idea-hunt skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
+- [idea-hunt](https://github.com/ANVEAI/idea-hunt-skill) - Evidence-first AI business idea discovery and validation: finds a painful, already-paid-for workflow AI can replace, then proves willingness-to-pay before you build via kill-gates, the Mom Test, and a proof-of-wallet test.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
 


### PR DESCRIPTION
### Adding: idea-hunt

**Repo:** https://github.com/ANVEAI/idea-hunt-skill · MIT · single self-contained `SKILL.md` — no API key or paid subscription required to function.

**What it does:** Evidence-first AI business idea discovery & validation. It inverts the usual "invent an idea" prompt: it hunts for an existing, already-paid-for workflow AI can now do as *completed work*, then runs a 7-stage pipeline — pain mining → kill-gates → the Mom Test → a proof-of-wallet test — so weak ideas get rejected on paper before any build.

- [x] Actively maintained, documented (README + FAQ)
- [x] No commercial-API / paid-subscription dependency
- [x] Real value for Claude / Claude Code users
- [x] Concise, single-sentence description