### PR TITLE
Add Canvas Grid Engine (中文教育场景 Canvas 学习纸网格渲染引擎)

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Theme Factory](./theme-factory/) - Applies professional font and color themes to artifacts including slides, docs, reports, and HTML landing pages with 10 pre-set themes.
 - [Video Downloader](./video-downloader/) - Downloads videos from YouTube and other platforms for offline viewing, editing, or archival with support for various formats and quality options.
 - [youtube-transcript](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/youtube-transcript) - Fetch transcripts from YouTube videos and prepare summaries.
+- [Canvas Grid Engine](https://github.com/shuangying0001-beep/canvas-grid-engine) - 中文教育场景 Canvas 学习纸网格渲染引擎：一键生成 13 种练习纸网格（米字格/田字格/回宫格/四线三格/点阵/拼音标注等），汉字自动居中与换行、可导出打印；「Canvas 教育工具链」4 件套之一（另含 [SVG 零误差复刻](https://github.com/shuangying0001-beep/svg-to-canvas-replica) / [多页 PDF 导出](https://github.com/shuangying0001-beep/canvas-multipage-pdf) / [小程序 Canvas 视觉验证](https://github.com/shuangying0001-beep/miniprogram-canvas-verify)）。*By [@shuangying0001-beep](https://github.com/shuangying0001-beep)*
 
 ### Productivity & Organization
 


### PR DESCRIPTION
## 新增技能：Canvas Grid Engine

面向**中文教育场景**的 Canvas 学习纸网格渲染引擎 Skill。

- Repo: https://github.com/shuangying0001-beep/canvas-grid-engine
- 功能：一键生成 13 种练习纸网格（米字格 / 田字格 / 回宫格 / 九宫格 / 方格 / 横线 / 四线三格 / 点阵格 / 黄金圆格等），汉字自动居中、自动换行、拼音标注、微信绿设计令牌，可导出打印。
- 属于「Canvas 教育工具链」4 件套之一，另含：
  - [SVG 零误差复刻](https://github.com/shuangying0001-beep/svg-to-canvas-replica)
  - [多页 PDF 导出](https://github.com/shuangying0001-beep/canvas-multipage-pdf)
  - [小程序 Canvas 视觉验证](https://github.com/shuangying0001-beep/miniprogram-canvas-verify)
- 每个仓库均含 `SKILL.md` 与 `llms.txt`，可直接被 Agent 加载。

归入 `### Creative & Media` 章节，与该列表的媒体/设计类工具并列。感谢审阅！