### PR TITLE
Add Reelier (deterministic tool-call replay + drift diff)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Notion Meeting Intelligence](./notion-meeting-intelligence/) - Preps meetings from Notion context and creates internal pre-reads plus external agendas.
 - [Notion Research Documentation](./notion-research-documentation/) - Searches Notion, synthesizes multiple pages, and writes cited research docs back to Notion.
 - [Notion Spec To Implementation](./notion-spec-to-implementation/) - Turns Notion specs into task plans with acceptance criteria and progress tracking.
+- [Reelier](https://github.com/seldonframe/reelier) - Records an agent's tool-call workflow once, replays it deterministically at 0 tokens, and diffs runs to catch drift — CI and snapshot tests for MCP tool-call workflows, with an Agent Skill and MCP server in the same repo. *By [@seldonframe](https://github.com/seldonframe)*
 - [Taisly Agent Kit](https://github.com/taisly/agent) - Publishes approved short-form videos through Taisly with a reusable Agent Skill, Codex plugin, CLI, and remote MCP server.
 
 ### Document Processing


### PR DESCRIPTION
[Reelier](https://github.com/seldonframe/reelier) — Record an agent's tool-call workflow once, replay it deterministically at 0 tokens, and diff runs to catch drift — CI + snapshot tests for MCP tool-call workflows.

MCP server + Agent Skill in repo; listed in the official MCP registry as `io.github.seldonframe/reelier`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)