### PR TITLE
feat: add Suede Creator Skills to Development & Code Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 - [CCHub](https://github.com/Moresl/cchub) - A desktop control panel for the Claude Code / Codex / Gemini CLI ecosystem. Manage MCP servers, config profiles, agent skills, CLAUDE.md, hooks, and workflow templates from a single Tauri app (Windows / macOS / Linux).
-- [Suede Creator Skills](https://jasoncolapietro.github.io/suede-creator-skills/) - 23-skill pack for Claude Code and Codex: agent orchestration with WIP collision detection and rollback trees, a Codex CLI worker fleet, code review with an A-F ship grade across 7 evidence-backed lanes, AI eval scaffolding, plus design, copy, and SEO/AEO/AI-EO audits. MIT licensed. *By [@JasonColapietro](https://github.com/JasonColapietro)*
+- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - 71-skill pack for Claude Code and Codex: multi-agent orchestration, a Codex CLI worker fleet, code review with an A-F ship grade, AI eval scaffolding, CI gates, plus design, copy, and SEO/AEO/GEO audits. MIT licensed. *By [@JasonColapietro](https://github.com/JasonColapietro)*
 
 ### Data & Analysis
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 - [CCHub](https://github.com/Moresl/cchub) - A desktop control panel for the Claude Code / Codex / Gemini CLI ecosystem. Manage MCP servers, config profiles, agent skills, CLAUDE.md, hooks, and workflow templates from a single Tauri app (Windows / macOS / Linux).
+- [Suede Creator Skills](https://jasoncolapietro.github.io/suede-creator-skills/) - 23-skill pack for Claude Code and Codex: agent orchestration with WIP collision detection and rollback trees, a Codex CLI worker fleet, code review with an A-F ship grade across 7 evidence-backed lanes, AI eval scaffolding, plus design, copy, and SEO/AEO/AI-EO audits. MIT licensed. *By [@JasonColapietro](https://github.com/JasonColapietro)*
 
 ### Data & Analysis
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [using-git-worktrees](https://github.com/obra/superpowers/blob/main/skills/using-git-worktrees/) - Creates isolated git worktrees with smart directory selection and safety verification.
 - [Webapp Testing](./webapp-testing/) - Tests local web applications using Playwright for verifying frontend functionality, debugging UI behavior, and capturing screenshots.
 - [CCHub](https://github.com/Moresl/cchub) - A desktop control panel for the Claude Code / Codex / Gemini CLI ecosystem. Manage MCP servers, config profiles, agent skills, CLAUDE.md, hooks, and workflow templates from a single Tauri app (Windows / macOS / Linux).
-- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - 71-skill pack for Claude Code and Codex: multi-agent orchestration, a Codex CLI worker fleet, code review with an A-F ship grade, AI eval scaffolding, CI gates, plus design, copy, and SEO/AEO/GEO audits. MIT licensed. *By [@JasonColapietro](https://github.com/JasonColapietro)*
+- [Suede Creator Skills](https://github.com/JasonColapietro/suede-creator-skills) - Open-source skill pack for Claude Code and Codex: multi-agent orchestration, a Codex CLI worker fleet, code review with an A-F ship grade, AI eval scaffolding, CI gates, plus design, copy, and SEO/AEO/GEO audits. MIT licensed. *By [@JasonColapietro](https://github.com/JasonColapietro)*
 
 ### Data & Analysis
 


### PR DESCRIPTION
## What's being added

[Suede Creator Skills](https://jasoncolapietro.github.io/suede-creator-skills/) — a 23-skill pack for Claude Code and Codex.

**Source repo:** https://github.com/JasonColapietro/suede-creator-skills

## What it includes

- **Agent orchestration** — coordinate agent lanes with WIP collision detection, RFC mode, feature-flag strategy, and rollback trees
- **Codex worker fleets** — the Suede Fable Fleet: a Claude orchestrator decomposes work and spawns parallel OpenAI Codex CLI workers, reviewing every output against acceptance criteria
- **Code review + A-F ship grade** — findings across 7 evidence-backed lanes, with instant-F triggers and grade caps for auth/payment surfaces
- **AI evaluation** — AI-SPEC artifacts, failure-mode rubrics, eval cases, and acceptance gates for AI surfaces
- **Design, copy, and SEO** — design systems and visual QA, conversion copy with an anti-slop gate, SEO/AEO/AI-EO audits, A-F page visibility grades
- Plus a creator toolkit (rights, release prep) for music/media use cases

## Why it fits Development & Code Tools

The pack's primary focus is agent orchestration, code review/grading, and AI eval tooling. MIT licensed, runs locally, no uploads required by default.