### PR TITLE
Add NotFair to Developer Marketing Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,8 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 - [dev-gtm-claude-skills](https://github.com/Infrasity-Labs/dev-gtm-claude-skills) - Open-source, cross-platform agent skills for Claude Code and agentskills.io-compatible platforms. These skills are for SEO, GEO (Generative Engine Optimization), AI discoverability, and developer marketing.
 By [Infrasity-Labs](https://github.com/Infrasity-Labs)
+- [NotFair](https://github.com/nowork-studio/NotFair) - Open-source collection of 28 Claude Code skills for SEO, GEO, Google Ads, and Meta Ads workflows. Live Search Console and ad-account access is available through optional hosted NotFair MCP connections.
+By [nowork-studio](https://github.com/nowork-studio)
 
 ## Platforms
 


### PR DESCRIPTION
Adds the public NotFair skills repository to Developer Marketing Skills. It contains 28 SKILL.md workflows for SEO, GEO, Google Ads, and Meta Ads.

Disclosure: I’m submitting our own project. The skills are open source under MIT; optional live Search Console and ad-account access uses hosted NotFair MCP connections.

The README-only change follows the existing external-repository format in this section.