### PR TITLE
Add Arcgram — agent-neutral reasoning-diagram skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ### Development & Code Tools
 
+- [Arcgram](https://github.com/jovesun-lab/arcgram) - Turns an AI agent's reasoning into an auditable node-and-edge diagram you can inspect and correct — a single standalone HTML file, no build/npm/CDN. Agent-neutral (Claude, GPT, Gemini, Cursor, local LLMs) with headless Checkpoint/Reconcile/Validate self-checks. *By [@jovesun-lab](https://github.com/jovesun-lab)*
 - [artifacts-builder](https://github.com/anthropics/skills/tree/main/artifacts-builder) - Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, shadcn/ui).
 - [aws-skills](https://github.com/zxkane/aws-skills) - AWS development with CDK best practices, cost optimization MCP servers, and serverless/event-driven architecture patterns.
 - [Blueprint](https://github.com/JuliusBrussee/blueprint) - A Claude Code plugin for specification-driven development that turns natural language into blueprints, blueprints into parallel build plans, and build plans into working software with automated iteration and dual-model adversarial review. *By [@JuliusBrussee](https://github.com/JuliusBrussee)*


### PR DESCRIPTION
Adds Arcgram to Development & Code Tools.

Arcgram lets an AI agent surface its reasoning as an auditable node-and-edge diagram — a single, standalone HTML file (no build/npm/CDN) that a human can inspect and correct, rather than trusting a wall of prose. It's agent-neutral (Claude, GPT, Gemini, Cursor, local LLMs) and ships headless Checkpoint/Reconcile/Validate self-checks. Apache-2.0.

Repo: https://github.com/jovesun-lab/arcgram