### PR TITLE
Add Fact-Check-X skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Data & Analysis
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
+- [Fact-Check-X](https://github.com/ASI2030/Fact-Check-X/tree/main/skills/fact-check-x-complete) - Captures raw answers and citations from one or more AI platforms, compares atomic claims, verifies them against authoritative sources, and generates standalone HTML reports. *By [@ASI2030](https://github.com/ASI2030)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 


### PR DESCRIPTION
## Real-world use case

Fact-Check-X supports research and operations teams that need to compare answers from one or more AI platforms without losing the original evidence. It preserves each answer and citation, decomposes the result into atomic claims, verifies claims against authoritative sources, and produces standalone HTML reports. It has been used in live WorkBuddy verification workflows for public-policy and business questions.

## What this PR changes

- adds one external entry under **Data & Analysis**
- links directly to the complete `fact-check-x-complete` skill directory
- does not copy or trim the 94-file runtime

## Validation

- target directory returns HTTP 200
- Codex and Claude Code installation paths have been validated previously
- a fresh Gemini CLI-targeted install produced all 94 files, matched the public source byte-for-byte, and passed core module discovery
- browser, account, credential, and authoritative-search boundaries are documented; no credentials are bundled
- Apache-2.0 licensed

**Attribution:** [ASI2030/Fact-Check-X](https://github.com/ASI2030/Fact-Check-X)