### PR TITLE
Add hermes-llmwiki — Karpathy-native wiki memory skill for Hermes Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Raffle Winner Picker](./raffle-winner-picker/) - Randomly selects winners from lists, spreadsheets, or Google Sheets for giveaways and contests with cryptographically secure randomness.
 - [ship-learn-next](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/ship-learn-next) - Skill to help iterate on what to build or learn next, based on feedback loops.
 - [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code/tree/main/tapestry) - Interlink and summarize related documents into knowledge networks.
+- [hermes-llmwiki](https://github.com/chancelu/hermes-llmwiki) - Karpathy-native local Markdown wiki memory provider for Hermes Agent. Zero-infrastructure 3-layer architecture (Raw → Chronicle → Compiled), bidirectional read/write, Obsidian-compatible vault, schema-driven. PyPI: `pip install hermes-llmwiki`.
 
 ### Collaboration & Project Management
 


### PR DESCRIPTION
## What is hermes-llmwiki?

[hermes-llmwiki](https://github.com/chancelu/hermes-llmwiki) is a **Karpathy-native local Markdown wiki memory provider** for [Hermes Agent](https://github.com/nousresearch/hermes-agent). It implements Andrej Karpathy's LLM Wiki pattern as a native Hermes skill — turning your local Markdown vault into a compounding knowledge system.

### Why local wiki memory matters

Most AI agent memory solutions fall into two traps:
1. **SaaS lock-in** — your data lives on someone else's server
2. **Infrastructure bloat** — Docker + vector DB + Redis just to remember what happened yesterday

Karpathy's insight (from his widely-shared gist) is that **RAG is the wrong abstraction for agent memory**: the LLM rediscovers knowledge every single query instead of building on what it already knows. The fix is a structured wiki the agent can **both read from and write to** — compounding knowledge, not re-discovering it.

### Technical value

| | hermes-llmwiki | Typical alternatives |
|--|----------------|-------------------|
| Architecture | Karpathy 3-layer (Raw → Chronicle → Compiled) | RAG / vector search |
| Dependencies | Python + ripgrep + optional SQLite | Docker + Qdrant + Redis |
| Data ownership | 100% local Markdown | SaaS or managed DB |
| Agent integration | Native Hermes skill with CLI commands | Generic API wrapper |
| Vault format | Obsidian-compatible with wikilinks | Proprietary / JSON-only |
| Schema | SCHEMA.md drives structure | Hardcoded schema |
| Direction | Bidirectional (agent reads + writes) | Mostly read-only |

### PyPI release

v0.1.0 is live: pip install hermes-llmwiki

---
**Note:** Added to the Productivity & Organization section alongside tapestry, as both are knowledge-network tools.