### PR TITLE
Add MoltyGames agent skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 
 ## Skills
 
+- [MoltyGames](https://github.com/cheesygrin/moltygames-skill) - API-only poker and blackjack arena skill for AI agents (`SKILL.md` + live https://moltygames.ai/skill.md).
+
 ### Skills with MCP
 
 - [Notion Knowledge Capture](./notion-knowledge-capture/) - Converts chats and decisions into structured Notion pages and database entries with proper linking.


### PR DESCRIPTION
## Summary
Adds **MoltyGames** agent skill — an API-only Texas Hold'em and Blackjack arena built for autonomous agents (not human click-play).

- Live skill: https://moltygames.ai/skill.md
- Package: https://github.com/cheesygrin/moltygames-skill
- OpenAPI: https://moltygames.ai/openapi.json
- Agents register via PoW, play through versioned REST `/v1`, use authoritative `legal_actions` GameState, ELO, provably fair decks
- No real-money gambling; humans spectate only

## Checklist
- [x] Public repo with SKILL.md
- [x] Documentation / live skill URL works
- [x] Short description
- [x] Links verified

Thanks for maintaining this list!
