### PR TITLE
Add Zillow Skills to Data & Analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
+- [Zillow Skills](https://github.com/ZeroPointRepo/zillow-skills) - Runs comps and pulls Zestimates, listings, price history, photos, taxes, and schools for US homes from a plain language ask. Pure Python standard library, MIT-0 licensed, and it works with Claude, ChatGPT, OpenClaw, and Hermes Agent. *By [@ZeroPointRepo](https://github.com/ZeroPointRepo)*
 
 ### Business & Marketing
 


### PR DESCRIPTION
Adds **Zillow Skills** under Data & Analysis.

Real use case: pulling comps and valuations while working on a deal. The agent answers "what is this house worth and what did similar homes nearby sell for" directly, instead of the user tabbing through listing pages and copying numbers into a sheet.

Covers Zestimates, comps, listings for sale, sold and rental, price history, photos, taxes, and schools for US homes.

- Repo: https://github.com/ZeroPointRepo/zillow-skills (MIT-0)
- Pure Python standard library, no dependencies
- Works with Claude, ChatGPT, OpenClaw, and Hermes Agent
- Free tier, no card required

Zillapi is an independent service for Zillow-sourced data, not affiliated with or endorsed by Zillow. Single line added in the existing row format, alphabetical position at the end of the section.