### PR TITLE
Add multi-source-search skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Data & Analysis
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
-- [multi-source-search](https://github.com/sandbaseai/sandbase-skills/tree/v0.3.2/research/multi-source-search) - Researches claims across independent sources under an explicit retrieval budget, records conflicts in an evidence ledger, and validates the report offline before synthesis. *By [@sandbaseai](https://github.com/sandbaseai)*
+- [multi-source-search](https://github.com/sandbaseai/sandbase-skills/tree/v0.3.3/research/multi-source-search) - Researches claims across independent sources under an explicit retrieval budget, records conflicts in an evidence ledger, and validates the report offline before synthesis. *By [@sandbaseai](https://github.com/sandbaseai)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Data & Analysis
 
 - [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) - Automatically analyzes CSV files and generates comprehensive insights with visualizations without requiring user prompts. *By [@coffeefuelbump](https://github.com/coffeefuelbump)*
+- [multi-source-search](https://github.com/sandbaseai/sandbase-skills/tree/v0.3.2/research/multi-source-search) - Researches claims across independent sources under an explicit retrieval budget, records conflicts in an evidence ledger, and validates the report offline before synthesis. *By [@sandbaseai](https://github.com/sandbaseai)*
 - [postgres](https://github.com/sanjay3290/ai-skills/tree/main/skills/postgres) - Execute safe read-only SQL queries against PostgreSQL databases with multi-connection support and defense-in-depth security. *By [@sanjay3290](https://github.com/sanjay3290)*
 - [root-cause-tracing](https://github.com/obra/superpowers/tree/main/skills/root-cause-tracing) - Use when errors occur deep in execution and you need to trace back to find the original trigger.
 


### PR DESCRIPTION
## What problem it solves

Research agents often turn partial retrieval, duplicate coverage, or unresolved source conflicts into unjustified confidence. `multi-source-search` makes the stopping rule and evidence trail explicit: it works under a retrieval budget, requires independent sources, records support and contradiction, and validates a machine-readable evidence ledger before synthesis.

## Who uses this workflow

It is intended for developers, analysts, and researchers who need an auditable answer from a coding agent using the search/page tools already available in Claude Code, Codex, Gemini CLI, or another Agent Skills-compatible host. It does not require a SandBase account.

## Example

The repository includes:

- a worked branch-protection research example using primary documentation from GitHub, GitLab, and Atlassian
- a machine-readable evidence ledger
- an offline validator that rejects duplicate/unknown sources, unused evidence, inflated confidence, and unresolved high-confidence conflicts
- 21 Python tests plus repository/catalog tests
- a clean third-party `skill-validator v0.5.0` result (0 errors, 0 warnings)

Example prompt:

> Fact-check this claim with independent primary sources, stay within a six-source retrieval budget, record conflicts, and validate the evidence ledger before answering.

## Attribution and disclosure

The Skill is Apache-2.0 and maintained in [sandbaseai/sandbase-skills](https://github.com/sandbaseai/sandbase-skills). I help maintain that repository. This PR links to the tagged v0.3.2 Skill rather than copying it, consistent with existing external Skill entries in this list.

## Verification

- Skill: https://github.com/sandbaseai/sandbase-skills/tree/v0.3.2/research/multi-source-search
- Evidence ledger: https://github.com/sandbaseai/sandbase-skills/blob/v0.3.2/examples/verifiable-research-report.json
- Worked example on main: https://github.com/sandbaseai/sandbase-skills/blob/main/examples/branch-protection-research.md
- The diff is one alphabetically placed README entry; `git diff --check` passes.