### PR TITLE
Add pptx-to-html-trace to Document Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [pptx](https://github.com/anthropics/skills/tree/main/document-skills/pptx) - Read, generate, and adjust slides, layouts, templates.
 - [xlsx](https://github.com/anthropics/skills/tree/main/document-skills/xlsx) - Spreadsheet manipulation: formulas, charts, data transformations.
 - [Markdown to EPUB Converter](https://github.com/smerchek/claude-epub-skill) - Converts markdown documents and chat summaries into professional EPUB ebook files. *By [@smerchek](https://github.com/smerchek)*
+- [pptx-to-html-trace](https://github.com/JunoChenZt/pptx-to-html-trace) - Rebuilds a PowerPoint or PDF slide as HTML matching the original, with overlay and difference views so the match can be verified on screen. *By [@JunoChenZt](https://github.com/JunoChenZt)*
 
 ### Development & Code Tools
 


### PR DESCRIPTION
Adds one entry to **Document Processing**.

**[pptx-to-html-trace](https://github.com/JunoChenZt/pptx-to-html-trace)** rebuilds a PowerPoint or PDF slide as HTML that matches the original, and ships the original render alongside the page as a comparison layer so the match can actually be checked: HTML only · Reference only · Overlay · Difference. In difference mode matched pixels go black, so only the errors still glow.

### Not a duplicate of the existing `pptx` entry

The official `pptx` skill already listed here reads and generates slides — it works *inside* PowerPoint. This one goes the other way: it takes a finished slide and reproduces it as a web page, then gives you the instruments to prove the reproduction is faithful. Different direction, different output, no overlap in what they're used for.

It is also deliberately not a PPTX→HTML converter. Converters hand you a fidelity percentage and a manual checklist. This assumes the gap exists and hands you a way to measure and close it — a workbench rather than a finished player.

### Why a link instead of a vendored folder

CONTRIBUTING describes adding a `skill-name/SKILL.md` folder. This skill is `SKILL.md` **plus** a 65KB geometry extractor that reads the `.pptx` XML — copying only the Markdown in would produce a skill that cannot work. I followed the precedent of the Markdown to EPUB Converter entry and linked the source repo, so the code stays with its documentation and updates reach users automatically. Happy to restructure if you would rather vendor it.

### Against the requirements in CONTRIBUTING

- **Real use case** — built for reusing locked company and client deck templates on the web, and for slides where only a PDF export survives.
- **Documented** — README and `SKILL.md` in English and Simplified Chinese; `SKILL.md` is 312 lines.
- **Examples and tests** — test fixtures and an eval README are in the repo; a tagged release ships a ready-to-upload zip.
- **Portable** — a standard Agent Skills package. Install steps are documented and verified for ChatGPT, Claude.ai/Desktop, Claude Code and Codex. I have not tested it on Gemini CLI, so I am not claiming that one.
- **Safe** — the extractor is pure Python standard library: no dependencies, no network calls, no destructive operations. It only ever writes to the output directory you name.

MIT licensed.
