### PR TITLE
Add SandBase CLI Agent Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Notion Research Documentation](./notion-research-documentation/) - Searches Notion, synthesizes multiple pages, and writes cited research docs back to Notion.
 - [Notion Spec To Implementation](./notion-spec-to-implementation/) - Turns Notion specs into task plans with acceptance criteria and progress tracking.
 - [Taisly Agent Kit](https://github.com/taisly/agent) - Publishes approved short-form videos through Taisly with a reusable Agent Skill, Codex plugin, CLI, and remote MCP server.
+- [SandBase CLI](https://github.com/sandbaseai/cli/tree/main/skills/sandbase) - Official Agent Skill and local MCP bridge for connecting supported coding clients to 2,000+ AI models and APIs.
 
 ### Document Processing
 


### PR DESCRIPTION
Adds the official SandBase Agent Skill to the “Skills with MCP” section.

- Skill: https://github.com/sandbaseai/cli/tree/main/skills/sandbase
- The skill documents a local MCP bridge for supported clients and access to 2,000+ AI models and APIs.
- Disclosure: I am affiliated with SandBase and used AI assistance to prepare this factual entry.