### PR TITLE
Add BulkPublish social media content skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 ### Business & Marketing
 
 - [Brand Guidelines](./brand-guidelines/) - Applies Anthropic's official brand colors and typography to artifacts for consistent visual identity and professional design standards.
+- [BulkPublish Social Media Content](https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills) - Plans, adapts, reviews, schedules, publishes, and measures social media content for AI agents through BulkPublish.
 - [buyer-eval-skill](https://github.com/salespeak-ai/buyer-eval-skill) - Structured, evidence-based B2B software vendor evaluation skill. Engages vendor AI agents, scores vendors across 7 dimensions with transparent evidence tracking, and produces comparative scorecards with demo prep questions. Useful for procurement, RFP evaluation, and build-vs-buy decisions. *By [@salespeak-ai](https://github.com/salespeak-ai)*
 - [Competitive Ads Extractor](./competitive-ads-extractor/) - Extracts and analyzes competitors' ads from ad libraries to understand messaging and creative approaches that resonate.
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.

--- a/bulkpublish-social-media-content/SKILL.md
+++ b/bulkpublish-social-media-content/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: bulkpublish-social-media-content
+description: Plan, adapt, review, schedule, publish, and measure social media content for AI agents through BulkPublish.
+---
+
+# BulkPublish Social Media Content
+
+Use this skill for a reusable social publishing workflow across connected channels.
+
+## When to Use This Skill
+
+- Planning a multi-platform campaign
+- Adapting content to platform constraints
+- Reviewing drafts before publication
+- Scheduling and measuring approved posts through BulkPublish
+
+## How to Use
+
+1. Confirm the audience, objective, platforms, voice, timing, and approval requirements.
+2. Draft and adapt each post, including accessibility, disclosures, and factual checks.
+3. Prepare a BulkPublish draft and show the planned mutation before scheduling or publishing.
+4. Publish or schedule only after explicit user authorization.
+5. Use BulkPublish analytics to report results and recommend the next iteration.
+
+## Safety
+
+- Treat scheduling, publishing, editing, and deleting as destructive or externally visible actions.
+- Never expose credentials or claim success without verifying the BulkPublish result.
+- Prefer drafts and previews when requirements or approval status are unclear.
+
+## Resources
+
+- [BulkPublish social media skills](https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills)
+- [BulkPublish MCP documentation](https://app.bulkpublish.com/docs)


### PR DESCRIPTION
Adds a reusable social media content skill for AI agents using BulkPublish. It covers planning, platform adaptation, review, authorization-aware scheduling/publishing, and analytics.

This is a self-submission.
Source repository: https://github.com/azeemkafridi/bulkpublish-api
Skill collection: https://github.com/azeemkafridi/bulkpublish-api/tree/main/skills/social-media-content-skills
MCP docs: https://app.bulkpublish.com/docs