### PR TITLE
feat: add optional you.com search integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Notion Research Documentation](./notion-research-documentation/) - Searches Notion, synthesizes multiple pages, and writes cited research docs back to Notion.
 - [Notion Spec To Implementation](./notion-spec-to-implementation/) - Turns Notion specs into task plans with acceptance criteria and progress tracking.
 - [Taisly Agent Kit](https://github.com/taisly/agent) - Publishes approved short-form videos through Taisly with a reusable Agent Skill, Codex plugin, CLI, and remote MCP server.
+- [You.com Agent Skills](https://github.com/youdotcom-oss/agent-skills) - Current web search, URL content extraction, cited research, and finance research for coding agents, packaged as Agent Skills (`you-web`, `you-research`, `you-finance`, `you-discover`) with remote You.com MCP servers. Installable via `npx skills add youdotcom-oss/agent-skills` or as a Claude Code / Codex / Copilot CLI plugin.
 
 ### Document Processing
 


### PR DESCRIPTION
## What

One-line addition to the **Skills with MCP** section: [You.com Agent Skills](https://github.com/youdotcom-oss/agent-skills).

## Why it fits this catalog

I was looking for skill collections that give coding agents current web knowledge, and noticed this section already lists external skill packages that ship skills alongside remote MCP servers (Taisly Agent Kit, the Notion skills, dRPC). You.com's agent skills package fits the same shape:

- **Skills**: `you-web` (current web search, URL content extraction, cited synthesis), `you-research` (deep-research routing), `you-finance` (market research), `you-discover` (integration planning)
- **Remote MCP servers**: `https://api.you.com/mcp` (authenticated via `YDC_API_KEY` or OAuth) and a keyless profile at `https://api.you.com/mcp?profile=free` for basic search

It works across the platforms covered in this README — Claude Code, Codex, Gemini CLI, Qwen Code, OpenCode — since skills are plain `SKILL.md` folders.

## Install (for anyone who finds it via this listing)

```bash
npx skills add youdotcom-oss/agent-skills
```

Or as a plugin:

```
/plugin marketplace add youdotcom-oss/agent-skills
/plugin install you@you-com
```

## Changes

- `README.md`: one bullet in the Skills with MCP section, following the existing entry format (name → repo link + one-line description). No other changes; nothing in the repo's default behavior is affected since it's a docs-only catalog entry.

## Validation

- Confirmed the entry matches the format of sibling entries (Taisly, dRPC, Notion).
- Verified the linked repo and install command against the upstream README.
- No existing you.com entry in the catalog (checked for duplicates per the contribution guide).

Happy to trim the description or move it to a different section if you'd prefer — I kept it next to the other MCP-backed skill packages.

Tracking: youdotcom-oss/integration-tracking#239