### PR TITLE
Add WorkBuddy Skill Atlas resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ We welcome contributions! Please read our [Contributing Guidelines](CONTRIBUTING
 - [Claude Community](https://community.anthropic.com) - Discuss skills with other users
 - [Skills Marketplace](https://claude.ai/marketplace) - Discover and share skills
 - [Notion Skills](https://www.notion.so/notiondevs/Notion-Skills-for-Claude-28da4445d27180c7af1df7d8615723d0) - Notion integration skills
+- [WorkBuddy Skill Atlas](https://sandbaseai.github.io/workbuddy-skill/) - Search 10,000+ public skills with immutable provenance, duplicate detection, compatibility scores, and static review signals
 
 ## License
 


### PR DESCRIPTION
## Summary

Add WorkBuddy Skill Atlas to Community Resources as a WorkBuddy-focused discovery and review tool.

## Why it is useful

- indexes 10,000+ public `SKILL.md` paths
- preserves immutable GitHub provenance
- groups duplicate content by blob SHA
- exposes WorkBuddy compatibility and conservative static review signals
- provides an open-source review and adaptation workflow

## Verification

- resource URL returns HTTP 200
- entry follows the existing one-line Community Resources format
- `git diff --check` passes