### PR TITLE
Add Product Manager OS to Business & Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ LLM Skills are customizable workflows that teach LLM how to perform specific tas
 - [Domain Name Brainstormer](./domain-name-brainstormer/) - Generates creative domain name ideas and checks availability across multiple TLDs including .com, .io, .dev, and .ai extensions.
 - [Internal Comms](./internal-comms/) - Helps write internal communications including 3P updates, company newsletters, FAQs, status reports, and project updates using company-specific formats.
 - [Lead Research Assistant](./lead-research-assistant/) - Identifies and qualifies high-quality leads by analyzing your product, searching for target companies, and providing actionable outreach strategies.
+- [Product Manager OS](https://github.com/Sidsaladi9/persona-os) - 53 product management skills spanning discovery, user research, strategy, planning, specs, metrics and go-to-market, each grounded in the standard reference on its topic. Adds a memory that keeps product, team and decision context between sessions, plus a weekly loop that drafts the missing skill from work you repeat. Every skill scored out of 100 in CI. *By [@Sidsaladi9](https://github.com/Sidsaladi9)*
 
 ### Communication & Writing
 


### PR DESCRIPTION
Adding **Product Manager OS** — a product-management skill collection — to *Business & Marketing*.

**Repo:** https://github.com/Sidsaladi9/persona-os · MIT · public

53 skills across discovery, user research, strategy, planning, specs, metrics, go-to-market and team comms, each grounded in the standard reference on its topic (The Mom Test, Inspired, Continuous Discovery Habits, Obviously Awesome, Good Strategy Bad Strategy, Measure What Matters).

Two parts that go beyond a skill pack:

- A `memory/` folder holding product, team, constraints and decisions, so skills stop re-asking for context every session
- A weekly loop that reads a log of repeated work and drafts the missing skill from your own examples — required to say so and stop when the signal is thin

Every skill is scored out of 100 by a scorer running in CI with the score committed, so a regression shows up in the diff. One source builds bundles for Claude Code, Cowork, Codex, Cursor and Gemini CLI.

Checked first:
- [x] Real use case, not hypothetical — built for my own PM work
- [x] Searched for duplicates; nothing equivalent listed
- [x] Public repo, MIT, links verified
- [x] Format and `*By [@handle]*` attribution match surrounding entries

Happy to trim the description or move categories if you'd rather.